### PR TITLE
fix for exception when searching for terms like 'keyword or' 'keyword and' 

### DIFF
--- a/lib/scoped_search/query_language/parser.rb
+++ b/lib/scoped_search/query_language/parser.rb
@@ -18,6 +18,7 @@ module ScopedSearch::QueryLanguage::Parser
   # Start the parsing process by parsing an expression sequence
   def parse
     @tokens = tokenize
+    @tokens.delete_at(@tokens.size - 1) if @tokens.last.is_a?(Symbol)
     parse_expression_sequence(true).simplify
   end
 


### PR DESCRIPTION
Hello, 

Sometimes we got such searches in our application, 
It could be mistyping or mistake, 
I thought raised exception not good even if it is handled well in the app,

so I simply delete last word from query string if it is keyword.
