### PR TITLE
PostgreSQL Full Text Search

### DIFF
--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -118,7 +118,7 @@ module ScopedSearch
           @ext_method       = options[:ext_method]
           @operators        = options[:operators]
           @only_explicit    = !!options[:only_explicit]
-          @full_text_search    = !!options[:full_text_search]
+          @full_text_search  = options[:full_text_search]
           @default_operator = options[:default_operator] if options.has_key?(:default_operator)
         end
 

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -468,7 +468,8 @@ module ScopedSearch
         if [:like, :unlike].include?(operator) and field.full_text_search
           yield(:parameter, value)
           negation = (operator == :unlike) ? "NOT " : ""
-          return "#{negation}to_tsvector('english', #{field.to_sql(operator, &block)}) #{self.sql_operator(operator, field)} to_tsquery('english', ?)"
+          locale = (field.full_text_search == true) ? 'english' : field.full_text_search
+          return "#{negation}to_tsvector('#{locale}', #{field.to_sql(operator, &block)}) #{self.sql_operator(operator, field)} to_tsquery('#{locale}', ?)"
         else
           super
         end


### PR DESCRIPTION
The included changes implement full text searching on postgresql. This allows for indexes to be used during searching which can increase query speed to near sphinx / lucene levels.

An updated definition using this would be the following (where english is the locale).

<pre>scoped_search on: :name, full_text_search: :english</pre>


To gain the speed benefit an index must be manually created:

<pre>CREATE INDEX widgets_name_full_text_search ON widgets USING gin(to_tsvector('english', name));</pre>


This replaces ILIKE as the query used, however, it is not a drop in replacement for ILIKE in functionality. This performs more complex matching but at the same time doesn't do things like matching substrings.
