### PR TITLE
Fix for search queries with leading .

### DIFF
--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -176,7 +176,7 @@ module ScopedSearch
       field = fields[name.to_sym] unless name.blank?
       if field.nil?
         dotted = name.to_s.split('.')[0]
-        field = fields[dotted.to_sym] unless dotted.nil?
+        field = fields[dotted.to_sym] unless dotted.blank?
       end
       field
     end


### PR DESCRIPTION
We were running into issues in our application when using a search string that started with a .

For example searching for .com would cause scoped_search to try and intern an empty string.

Changing the check on dotted from .nil? to .blank? appears to have fixed the problem.
