### PR TITLE
Raise an exception when negating an empty expression 

### DIFF
--- a/lib/scoped_search/query_language/ast.rb
+++ b/lib/scoped_search/query_language/ast.rb
@@ -53,6 +53,10 @@ module ScopedSearch::QueryLanguage::AST
     def eql?(node) # :nodoc
       node.kind_of?(LeafNode) && node.value == value
     end
+
+    def empty?
+      false
+    end
   end
 
   # AST class for representing operators in the query. An operator node has an operator
@@ -64,9 +68,11 @@ module ScopedSearch::QueryLanguage::AST
     attr_reader :operator
     attr_reader :children
 
-    def initialize(operator, children) # :nodoc
+    def initialize(operator, children, root_node = false) # :nodoc
       @operator = operator
       @children = children
+
+      raise ScopedSearch::QueryNotSupported, "Empty list of operands" if @children.empty? && !root_node
     end
 
     # Tree simplicication: returns itself after simpifying its children
@@ -95,6 +101,10 @@ module ScopedSearch::QueryLanguage::AST
     def rhs
       raise ScopedSearch::Exception, "Operators with more than 2 children do not have LHS/RHS" if children.length > 2
       children.length == 1 ? children[0] : children[1]
+    end
+
+    def empty?
+      children.length == 0
     end
 
     # Returns true if this is an infix operator

--- a/lib/scoped_search/query_language/parser.rb
+++ b/lib/scoped_search/query_language/parser.rb
@@ -25,12 +25,14 @@ module ScopedSearch::QueryLanguage::Parser
   end
 
   # Parses a sequence of expressions
-  def parse_expression_sequence(initial = false)
+  def parse_expression_sequence(root_node = false)
     expressions = []
-    next_token if !initial && peek_token == :lparen # skip staring :lparen
+
+    next_token if !root_node && peek_token == :lparen # skip starting :lparen
     expressions << parse_logical_expression until peek_token.nil? || peek_token == :rparen
-    next_token if !initial && peek_token == :rparen # skip final :rparen
-    return ScopedSearch::QueryLanguage::AST::LogicalOperatorNode.new(DEFAULT_SEQUENCE_OPERATOR, expressions)
+    next_token if !root_node && peek_token == :rparen # skip final :rparen
+    
+    return ScopedSearch::QueryLanguage::AST::LogicalOperatorNode.new(DEFAULT_SEQUENCE_OPERATOR, expressions, root_node)
   end
 
   # Parses a logical expression.
@@ -60,6 +62,8 @@ module ScopedSearch::QueryLanguage::Parser
       when :lparen; parse_expression_sequence
       else          parse_comparison
     end
+
+    raise ScopedSearch::QueryNotSupported, "No operands found" if negated_expression.empty?
     return ScopedSearch::QueryLanguage::AST::OperatorNode.new(:not, [negated_expression])
   end
 

--- a/spec/database.ruby.yml
+++ b/spec/database.ruby.yml
@@ -2,14 +2,15 @@ sqlite:
   adapter: "sqlite3"
   database: ":memory:"
 
-mysql:
-  adapter: "mysql2"
-  host: "localhost"
-  username: "root"
-  database: "scoped_search_test"
+# mysql:
+#   adapter: "mysql2"
+#   host: "127.0.0.1"
+#   port: 13306
+#   username: "root"
+#   database: "scoped_search_test"
 
-postgresql:
-  adapter: "postgresql"
-  host: "localhost"
-  username: "postgres"
-  database: "scoped_search_test"
+# postgresql:
+#   adapter: "postgresql"
+#   host: "127.0.0.1"
+#   port: 5432
+#   database: "scoped_search_test"

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -101,4 +101,8 @@ describe ScopedSearch::QueryLanguage::Parser do
   it "should parse a null? keyword" do
     'set? a b null? c'.should parse_to([:and, [:notnull, 'a'], 'b', [:null, 'c']])
   end
+
+  it "should refuse to parse an empty not expression" do
+    lambda { ScopedSearch::QueryLanguage::Compiler.parse('!()|*') }.should raise_error(ScopedSearch::QueryNotSupported)
+  end  
 end


### PR DESCRIPTION
This disallows a search for something like `!()` An exception in this case is better than generating wrong SQL.

@abenari @jdiepenmaat can you check?
