### PR TITLE
Fix sorting by field named "description"

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -89,10 +89,11 @@ module ScopedSearch
     def order_by(order, &block)
       order ||= definition.default_order
       return nil if order.blank?
-      field = definition.field_by_name(order.to_s.split(' ')[0])
-      raise ScopedSearch::QueryNotSupported, "the field '#{order.to_s.split(' ')[0]}' in the order statement is not valid field for search" unless field
+      field_name, direction_name = order.split(/\s+/, 2)
+      field = definition.field_by_name(field_name)
+      raise ScopedSearch::QueryNotSupported, "the field '#{field_name}' in the order statement is not valid field for search" unless field
       sql = field.to_sql(&block)
-      direction = (order.to_s.downcase.include?('desc')) ? " DESC" : " ASC"
+      direction = (direction_name.downcase.eql?('desc')) ? " DESC" : " ASC"
       order = sql + direction
 
       return order

--- a/spec/integration/string_querying_spec.rb
+++ b/spec/integration/string_querying_spec.rb
@@ -9,15 +9,21 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
     before(:all) do
       ScopedSearch::RSpec::Database.establish_named_connection(db)
     
-      @class = ScopedSearch::RSpec::Database.create_model(:string => :string, :another => :string, :explicit => :string) do |klass|
+      @class = ScopedSearch::RSpec::Database.create_model(
+          :string => :string,
+          :another => :string,
+          :explicit => :string,
+          :description => :string
+          ) do |klass|
         klass.scoped_search :on => :string
         klass.scoped_search :on => :another,  :default_operator => :eq, :alias => :alias, :default_order => :desc
         klass.scoped_search :on => :explicit, :only_explicit => true
+        klass.scoped_search :on => :description
       end
 
-      @class.create!(:string => 'foo', :another => 'temp 1', :explicit => 'baz')
-      @class.create!(:string => 'bar', :another => 'temp 2', :explicit => 'baz')
-      @class.create!(:string => 'baz', :another => nil,      :explicit => nil)
+      @class.create!(:string => 'foo', :another => 'temp 1', :explicit => 'baz', :description => '1 - one')
+      @class.create!(:string => 'bar', :another => 'temp 2', :explicit => 'baz', :description => '2 - two')
+      @class.create!(:string => 'baz', :another => nil,      :explicit => nil,   :description => '3 - three')
     end
 
     after(:all) do
@@ -202,7 +208,15 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         @class.search_for('',:order => 'string DESC').first.string.should eql('foo')
       end
 
-       it "default order by another DESC" do
+      it "sort by description ASC" do
+        @class.search_for('',:order => 'description ASC').first.description.should eql('1 - one')
+      end
+
+      it "sort by description DESC" do
+        @class.search_for('',:order => 'description DESC').first.description.should eql('3 - three')
+      end
+
+      it "default order by another DESC" do
         @class.search_for('').first.string.should eql('bar')
       end
 


### PR DESCRIPTION
Ascending sort wasn't working, because we were searching the string
"description ASC" for the substring "desc".
