### PR TITLE
Allow ordering by field symbol (regression)

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -89,11 +89,11 @@ module ScopedSearch
     def order_by(order, &block)
       order ||= definition.default_order
       return nil if order.blank?
-      field_name, direction_name = order.split(/\s+/, 2)
+      field_name, direction_name = order.to_s.split(/\s+/, 2)
       field = definition.field_by_name(field_name)
       raise ScopedSearch::QueryNotSupported, "the field '#{field_name}' in the order statement is not valid field for search" unless field
       sql = field.to_sql(&block)
-      direction = (direction_name.downcase.eql?('desc')) ? " DESC" : " ASC"
+      direction = (!direction_name.nil? && direction_name.downcase.eql?('desc')) ? " DESC" : " ASC"
       order = sql + direction
 
       return order

--- a/spec/integration/string_querying_spec.rb
+++ b/spec/integration/string_querying_spec.rb
@@ -226,6 +226,10 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
 
         Set.new(distinct_search.map(&:explicit)).should == Set['baz', nil]
       end
+
+      it 'should order using symbol' do
+        @class.search_for('',:order => :string).first.string.should eql('bar')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes regression introduced by fix for Issue #75 in commit 
c4a53de89c6d1886aa7960afd34e715dda080393.  It wasn't documented or tested,
but previously we supported using a field symbol for the "order" option of
search_for.  This commit adds that capability back (and a test).
