### PR TITLE
depracating javascript in helper method used in pre-assets pipe-line code

### DIFF
--- a/lib/scoped_search/rails_helper.rb
+++ b/lib/scoped_search/rails_helper.rb
@@ -219,5 +219,7 @@ module ScopedSearch
           auto_complete_field_jquery(method, url, completion_options)
     end
 
+    deprecate :auto_complete_field_tag_jquery, :auto_complete_field_tag, :auto_complete_result
+
   end
 end


### PR DESCRIPTION
This fix is part of issue #89.
