### PR TITLE
fixed integer value auto completer

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -128,7 +128,7 @@ module ScopedSearch
     def build_suggestions(suggestions, is_value)
       return [] if (suggestions.blank?)
 
-      q=query
+      q = query
       unless q =~ /(\s|\)|,)$/ || last_token_is(COMPARISON_OPERATORS)
         val = Regexp.escape(tokens.last.to_s).gsub('\*', '.*')
         suggestions = suggestions.map {|s| s if s.to_s =~ /^"?#{val}"?/i}.compact
@@ -201,7 +201,7 @@ module ScopedSearch
       return complete_key_value(field, token, val) if field.key_field
 
       completer_scope(field)
-        .where(value_conditions(field.quoted_field, val))
+        .where(value_conditions(field, val))
         .select("DISTINCT #{field.quoted_field}")
         .limit(20)
         .map(&field.field)
@@ -261,7 +261,7 @@ module ScopedSearch
 
     # This method returns conditions for selecting completion from partial value
     def value_conditions(field, val)
-      val.blank? ? nil : "#{field.quoted_field} LIKE '#{val.gsub("'","''")}%'".tr_s('%*', '%')
+      val.blank? ? nil : "CAST(#{field.quoted_field} as CHAR(50)) LIKE '#{val.gsub("'","''")}%'".tr_s('%*', '%')
     end
 
     # This method complete infix operators by field type

--- a/spec/integration/auto_complete_spec.rb
+++ b/spec/integration/auto_complete_spec.rb
@@ -35,7 +35,8 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         has_many :bars
         default_scope { order(:string) }
 
-        scoped_search :on => [:string, :int, :date]
+        scoped_search :on => [:string, :date]
+        scoped_search :on => [:int], :complete_value => true
         scoped_search :on => :another,  :default_operator => :eq, :alias => :alias
         scoped_search :on => :explicit, :only_explicit => true, :complete_value => true
         scoped_search :on => :deprecated, :complete_enabled => false
@@ -49,7 +50,7 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
       end
 
       @foo_1 = Foo.create!(:string => 'foo', :another => 'temp 1', :explicit => 'baz', :int => 9  , :date => 'February 8, 2011' , :unindexed => 10)
-      Foo.create!(:string => 'bar', :another => 'temp 2', :explicit => 'baz', :int => 9  , :date => 'February 10, 2011', :unindexed => 10)
+      Foo.create!(:string => 'bar', :another => 'temp 2', :explicit => 'baz', :int => 22  , :date => 'February 10, 2011', :unindexed => 10)
       Foo.create!(:string => 'baz', :another => nil,      :explicit => nil  , :int => nil, :date => nil                 , :unindexed => nil)
 
       Bar.create!(:related => 'lala',         :foo => @foo_1)
@@ -176,6 +177,7 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
       end
     end
 
+
     context 'exceptional search strings' do
 
       it "query that starts with 'or'" do
@@ -212,6 +214,12 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         Foo.complete_for('b').length.should == 4
       end
 
+    end
+
+    context 'autocompleting integer comparisons' do
+      it 'should autocomplete numerical fields' do
+        Foo.complete_for('int > 2').first.should match(/22/)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix auto completer for in on PostgreSQL by using the Cast function to cast int to char before using the like operator. and updated the test to verify the new functionality. 