### PR TITLE
Make sure search_for always return an AR Relation

### DIFF
--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -250,7 +250,7 @@ module ScopedSearch
     def register_named_scope! # :nodoc
       definition = self
       @klass.scope(:search_for, proc { |query, options|
-        search_scope = ActiveRecord::VERSION::MAJOR == 3 ? @klass.scoped : @klass
+        search_scope = ActiveRecord::VERSION::MAJOR == 3 ? @klass.scoped : (ActiveRecord::VERSION::MINOR < 1 ? @klass.where(nil) : @klass.all)
 
         find_options = ScopedSearch::QueryBuilder.build_query(definition, query || '', options || {})
         search_scope = search_scope.where(find_options[:conditions])   if find_options[:conditions]

--- a/spec/integration/string_querying_spec.rb
+++ b/spec/integration/string_querying_spec.rb
@@ -31,6 +31,51 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
       ScopedSearch::RSpec::Database.close_connection
     end
 
+    context 'with no scoped_search defaults' do
+
+      before(:all) do
+        @class2 = ScopedSearch::RSpec::Database.create_model(
+            :string => :string,
+            :another => :string,
+            ) do |klass|
+          klass.scoped_search :on => :string
+          klass.scoped_search :on => :another
+        end
+
+        @class2.create!(:string => 'foo', :another => 'foo')
+        @class2.create!(:string => 'bar', :another => 'foo')
+        @class2.create!(:string => 'baz', :another => 'bar')
+      end
+
+      after(:all) do
+        ScopedSearch::RSpec::Database.drop_model(@class2)
+      end
+
+      context '#search_for with an empty string' do
+
+        it 'should not remove previous scope' do
+          @class2.where(another: 'foo').search_for('').count.should == 2
+        end
+
+        it 'should return an ActiveRecord::Relation' do
+          @class2.search_for('').should be_a(ActiveRecord::Relation)
+        end
+
+      end
+
+      context '#search_for with nil' do
+        it 'should not remove previous scope' do
+          @class2.where(another: 'foo').search_for(nil).count.should == 2
+        end
+
+        it 'should return an ActiveRecord::Relation' do
+          @class2.search_for(nil).should be_a(ActiveRecord::Relation)
+        end
+
+      end
+
+    end
+
     context 'in an implicit string field' do
       it "should find the record with an exact string match" do
         @class.search_for('foo').length.should == 1


### PR DESCRIPTION
ScopedSearch::Definition#register_named_scope! can return a bare model class when used with ActiveRecord 4.x if ScopedSearch::QueryBuilder returns no find_options.
Under AR 3.x it returns @klass.scoped, in AR 4.x that should by @klass.all or (due a bug in AR 4.0) @klass.where(nil)

Note that this can create a serious security issue. E.g:

    [1] pry(main)> Invoice.count
    => 148
    [2] pry(main)> Company.first.invoices.count
    => 20
    [3] pry(main)> Company.first.invoices.search_for('').count
    => 148
