### PR TITLE
use active record "uniq" to apply distinct for auto-complete

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -176,11 +176,12 @@ module ScopedSearch
 
       field.key_klass
         .where(value_conditions(field_name, val))
-        .select("DISTINCT #{field_name}")
+        .select("#{field_name}")
         .limit(20)
         .map(&field.key_field)
         .compact
         .map { |f| "#{name}.#{f} " }
+        .uniq
     end
 
     # this method auto-completes values of fields that have a :complete_value marker
@@ -202,11 +203,12 @@ module ScopedSearch
 
       completer_scope(field)
         .where(value_conditions(field, val))
-        .select("DISTINCT #{field.quoted_field}")
+        .select("#{field.quoted_field}")
         .limit(20)
         .map(&field.field)
         .compact
         .map { |v| v.to_s =~ /\s/ ? "\"#{v}\"" : v }
+        .uniq
     end
 
     def completer_scope(field)

--- a/spec/integration/auto_complete_spec.rb
+++ b/spec/integration/auto_complete_spec.rb
@@ -89,6 +89,10 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         Foo.complete_for('date ').should =~ (["date  = ", "date  < ", "date  > "])
       end
 
+      it "should complete when query is already distinct" do
+        Foo.uniq.complete_for('int =').length.should > 0
+      end
+
       it "should raise error for unindexed field" do
         lambda { Foo.complete_for('unindexed = 10 ')}.should raise_error(ScopedSearch::QueryNotSupported)
       end


### PR DESCRIPTION
prior to this change auto-completing any attribute that existed on the same
table as the class would fail if the query already had 'distinct' applied.
The resulting query would have distinct twice, as seen by the added integration test run on master:

Failure/Error: Foo.uniq.complete_for('int =').length.should > 0
ActiveRecord::StatementInvalid:
  PG::SyntaxError: ERROR:  syntax error at or near "DISTINCT"
  LINE 1: SELECT  DISTINCT DISTINCT "foos"."int" FROM "foos"  ORDER BY...
                           ^
  : SELECT  DISTINCT DISTINCT "foos"."int" FROM "foos"  ORDER BY "foos"."int" LIMIT 20