### PR TITLE
Show correct styling for current sort order

### DIFF
--- a/lib/scoped_search/rails_helper.rb
+++ b/lib/scoped_search/rails_helper.rb
@@ -22,7 +22,7 @@ module ScopedSearch
 
       ascend  = "#{field} ASC"
       descend = "#{field} DESC"
-      selected = [ascend, descend].include?(params[:order])
+      selected_sort = [ascend, descend].find { |o| o == params[:order] }
 
       case params[:order]
         when ascend
@@ -33,9 +33,9 @@ module ScopedSearch
           new_sort = ["ASC", "DESC"].include?(options[:default]) ? "#{field} #{options[:default]}" : ascend
       end
 
-      if selected
+      unless selected_sort.nil?
         css_classes = html_options[:class] ? html_options[:class].split(" ") : []
-        if new_sort == ascend
+        if selected_sort == ascend
           options[:as] = "&#9650;&nbsp;#{options[:as]}"
           css_classes << "ascending"
         else

--- a/spec/unit/rails_helper_spec.rb
+++ b/spec/unit/rails_helper_spec.rb
@@ -70,4 +70,26 @@ describe ScopedSearch::RailsHelper do
     params[:order] = "field ASC"
     sort("other")
   end
+
+  it "should add no styling by default" do
+    should_receive(:url_for)
+    should_receive(:a_link).with('Field', anything, hash_excluding(:class))
+    sort("field")
+  end
+
+  it "should add ascending style for current ascending sort order " do
+    should_receive(:url_for)
+    should_receive(:a_link).with('&#9650;&nbsp;Field', anything, hash_including(:class => 'ascending'))
+
+    params[:order] = "field ASC"
+    sort("field")
+  end
+
+  it "should add descending style for current descending sort order " do
+    should_receive(:url_for)
+    should_receive(:a_link).with('&#9660;&nbsp;Field', anything, hash_including(:class => 'descending'))
+
+    params[:order] = "field DESC"
+    sort("field")
+  end
 end


### PR DESCRIPTION
sort() previously showed an arrow pointing up when the current sort
order was descending, and vice versa.  Changed from showing the style
for the linked, future order to the current order.