### PR TITLE
Fix auto-completion of partial key name in key/value configurations

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -202,7 +202,7 @@ module ScopedSearch
       return complete_key_value(field, token, val) if field.key_field
 
       completer_scope(field)
-        .where(value_conditions(field, val))
+        .where(value_conditions(field.quoted_field, val))
         .select("#{field.quoted_field}")
         .limit(20)
         .map(&field.field)
@@ -253,7 +253,7 @@ module ScopedSearch
       end
 
       query
-        .where(value_conditions(field, val))
+        .where(value_conditions(field.quoted_field, val))
         .select("DISTINCT #{field.quoted_field}")
         .limit(20)
         .map(&field.field)
@@ -262,8 +262,8 @@ module ScopedSearch
     end
 
     # This method returns conditions for selecting completion from partial value
-    def value_conditions(field, val)
-      val.blank? ? nil : "CAST(#{field.quoted_field} as CHAR(50)) LIKE '#{val.gsub("'","''")}%'".tr_s('%*', '%')
+    def value_conditions(field_name, val)
+      val.blank? ? nil : "CAST(#{field_name} as CHAR(50)) LIKE '#{val.gsub("'","''")}%'".tr_s('%*', '%')
     end
 
     # This method complete infix operators by field type

--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -176,7 +176,7 @@ module ScopedSearch
 
       field.key_klass
         .where(value_conditions(field_name, val))
-        .select("#{field_name}")
+        .select(field_name)
         .limit(20)
         .map(&field.key_field)
         .compact
@@ -203,7 +203,7 @@ module ScopedSearch
 
       completer_scope(field)
         .where(value_conditions(field.quoted_field, val))
-        .select("#{field.quoted_field}")
+        .select(field.quoted_field)
         .limit(20)
         .map(&field.field)
         .compact

--- a/spec/integration/key_value_querying_spec.rb
+++ b/spec/integration/key_value_querying_spec.rb
@@ -91,6 +91,10 @@ require "spec_helper"
           Item.complete_for('facts.').length.should == 2
         end
 
+        it "should complete facts names with partial name" do
+          Item.complete_for('facts.c').length.should == 1
+        end
+
         it "should complete values for fact name = color" do
           Item.complete_for('facts.color = ').length.should == 2
         end


### PR DESCRIPTION
Previously either a field or a quoted field string was passed into
value_conditions, causing the following error when expanding
auto-complete values for partial keys:

    NoMethodError:
      undefined method `quoted_field' for "\"keys\".\"name\"":String
    # ./lib/scoped_search/auto_complete_builder.rb:266:in `value_conditions'
    # ./lib/scoped_search/auto_complete_builder.rb:178:in `complete_key'