### PR TITLE
Fixes issue #139

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -28,9 +28,12 @@ module ScopedSearch
     # Loads the QueryBuilder class for the connection of the given definition.
     # If no specific adapter is found, the default QueryBuilder class is returned.
     def self.class_for(definition)
-      self.const_get(definition.klass.connection.class.name.split('::').last)
-    rescue
-      self
+      case definition.klass.connection.class.name.split('::').last
+      when /postgresql/i
+        PostgreSQLAdapter
+      else
+        self
+      end
     end
 
     # Initializes the instance by setting the relevant parameters

--- a/spec/unit/query_builder_spec.rb
+++ b/spec/unit/query_builder_spec.rb
@@ -8,6 +8,7 @@ describe ScopedSearch::QueryBuilder do
     @definition.stub(:profile).and_return(:default)
     @definition.stub(:default_order).and_return(nil)
     @definition.stub(:profile=).and_return(true)
+    @definition.klass.stub(:connection).and_return(double())
   end
 
   it "should raise an ArgumentError if the query is not set" do
@@ -22,4 +23,14 @@ describe ScopedSearch::QueryBuilder do
     ScopedSearch::QueryBuilder.build_query(@definition, "\t ").should == {  }
   end
 
+  it "should use default adapter when connection type is unknown" do
+    ScopedSearch::QueryBuilder.class_for(@definition).should == ScopedSearch::QueryBuilder
+  end
+
+  it "should use postgres adapter for postgres-like connection" do
+    connection = double()
+    connection.stub("name").and_return("SomePostgreSQLAdapter")
+    @definition.klass.connection.stub("class").and_return(connection)
+    ScopedSearch::QueryBuilder.class_for(@definition).should == ScopedSearch::QueryBuilder::PostgreSQLAdapter
+  end
 end


### PR DESCRIPTION
Instead of requiring the use of the default Rails PostgreSQL adapter
to make use of Postgres-specific scoped searches, try to guess if
the connection is PG based on the connection class name.