### PR TITLE
Fix Definition#register_named_scope! for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
 - "2.0"
 - "2.1"
 - "2.2.2"
-- "2.3.0"
+- "2.3.1"
 - ruby-head
 - jruby-19mode
 - jruby-head
@@ -39,3 +39,5 @@ matrix:
       gemfile: Gemfile.activerecord50
     - rvm: "2.1"
       gemfile: Gemfile.activerecord50
+    - rvm: "2.3.1"
+      gemfile: Gemfile.activerecord32

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ gemfile:
 - Gemfile.activerecord40
 - Gemfile.activerecord41
 - Gemfile.activerecord42
+- Gemfile.activerecord50
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ rvm:
 - "1.9"
 - "2.0"
 - "2.1"
-- "2.2"
+- "2.2.2"
+- "2.3.0"
 - ruby-head
 - jruby-19mode
 - jruby-head
@@ -28,6 +29,13 @@ gemfile:
 
 matrix:
   allow_failures:
-  - rvm: ruby-head
-  - rvm: jruby-head
-  - rvm: jruby-19mode
+    - rvm: ruby-head
+    - rvm: jruby-head
+    - rvm: jruby-19mode
+  exclude:
+    - rvm: "1.9"
+      gemfile: Gemfile.activerecord50
+    - rvm: "2.0"
+      gemfile: Gemfile.activerecord50
+    - rvm: "2.1"
+      gemfile: Gemfile.activerecord50

--- a/Gemfile.activerecord50
+++ b/Gemfile.activerecord50
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'activerecord', '5.0.0.rc1'
+
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+end
+
+platforms :ruby do
+  gem 'sqlite3'
+  gem 'mysql2', '~> 0.3.11'
+  gem 'pg'
+end

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -154,9 +154,6 @@ module ScopedSearch
     # Initializes a ScopedSearch definition instance.
     # This method will also setup a database adapter and create the :search_for
     # named scope if it does not yet exist.
-    # Initializes a ScopedSearch definition instance.
-    # This method will also setup a database adapter and create the :search_for
-    # named scope if it does not yet exist.
     def initialize(klass)
       @klass                 = klass
       @fields                = {}

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -154,6 +154,9 @@ module ScopedSearch
     # Initializes a ScopedSearch definition instance.
     # This method will also setup a database adapter and create the :search_for
     # named scope if it does not yet exist.
+    # Initializes a ScopedSearch definition instance.
+    # This method will also setup a database adapter and create the :search_for
+    # named scope if it does not yet exist.
     def initialize(klass)
       @klass                 = klass
       @fields                = {}
@@ -250,13 +253,15 @@ module ScopedSearch
     def register_named_scope! # :nodoc
       definition = self
       @klass.scope(:search_for, proc { |query, options|
+        klass = definition.klass
+
         search_scope = case ActiveRecord::VERSION::MAJOR
           when 3
-            @klass.scoped
+            klass.scoped
           when 4
-            (ActiveRecord::VERSION::MINOR < 1) ? @klass.where(nil) : @klass.all
+            (ActiveRecord::VERSION::MINOR < 1) ? klass.where(nil) : klass.all
           when 5
-            @klass.all
+            klass.all
           else
             raise ScopedSearch::DefinitionError, 'version ' \
               "#{ActiveRecord::VERSION::MAJOR} of activerecord is not supported"

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -250,7 +250,17 @@ module ScopedSearch
     def register_named_scope! # :nodoc
       definition = self
       @klass.scope(:search_for, proc { |query, options|
-        search_scope = ActiveRecord::VERSION::MAJOR == 3 ? @klass.scoped : (ActiveRecord::VERSION::MINOR < 1 ? @klass.where(nil) : @klass.all)
+        search_scope = case ActiveRecord::VERSION::MAJOR
+          when 3
+            @klass.scoped
+          when 4
+            (ActiveRecord::VERSION::MINOR < 1) ? @klass.where(nil) : @klass.all
+          when 5
+            @klass.all
+          else
+            raise ScopedSearch::DefinitionError, 'version ' \
+              "#{ActiveRecord::VERSION::MAJOR} of activerecord is not supported"
+          end
 
         find_options = ScopedSearch::QueryBuilder.build_query(definition, query || '', options || {})
         search_scope = search_scope.where(find_options[:conditions])   if find_options[:conditions]


### PR DESCRIPTION
I was getting the following running:

Rails 5.0.0.beta3
scoped_search 3.2.2
Ruby 2.3.0
MySQL 5.6.19

```
NoMethodError - undefined method `where' for nil:NilClass:
  scoped_search (3.2.2) lib/scoped_search/definition.rb:253:in `block in register_named_scope!'
  activerecord (5.0.0.beta3) lib/active_record/scoping/named.rb:159:in `block (2 levels) in scope'
  activerecord (5.0.0.beta3) lib/active_record/relation.rb:351:in `scoping'
  activerecord (5.0.0.beta3) lib/active_record/scoping/named.rb:159:in `block in scope'
  activerecord (5.0.0.beta3) lib/active_record/relation/delegation.rb:89:in `block in method_missing'
  activerecord (5.0.0.beta3) lib/active_record/relation.rb:351:in `scoping'
  activerecord (5.0.0.beta3) lib/active_record/relation/delegation.rb:89:in `method_missing'
  app/path/to/file.rb:12:in `results'
```

Changes:

* 5fb757e Handles Rails 5 explicitly so that it calls `@klass.all` over @klass.where(nil)
* 630f125 Changes `@klass` to `definition.klass` as `@klass` was returning `nil` inside the proc
