### PR TITLE
Filter URL parameters from ActionController::Parameters in sort helper

### DIFF
--- a/lib/scoped_search/rails_helper.rb
+++ b/lib/scoped_search/rails_helper.rb
@@ -13,7 +13,17 @@ module ScopedSearch
     # * <tt>:by</tt> - the name of the named scope. This helper will prepend this value with "ascend_by_" and "descend_by_"
     # * <tt>:as</tt> - the text used in the link, defaults to whatever is passed to :by
     # * <tt>:default</tt> - default sorting order, DESC or ASC
-    def sort(field, options = {}, html_options = {})
+    #
+    # url_options is a hash of URL parameters, defaulting to `params`, to preserve the current URL
+    # parameters.
+    #
+    # On Rails 5 or higher, parameter whitelisting prevents any parameter being used in a link by
+    # default, so `params.permit(..)` should be passed for `url_options` for all known and
+    # permitted URL parameters, e.g.
+    #
+    #   sort @search, {:by => :username}, {}, params.permit(:search)
+    #
+    def sort(field, options = {}, html_options = {}, url_options = params)
 
       unless options[:as]
         id           = field.to_s.downcase == "id"
@@ -45,7 +55,8 @@ module ScopedSearch
         html_options[:class] = css_classes.join(" ")
       end
 
-      url_options = params.merge(:order => new_sort)
+      url_options = url_options.to_h if url_options.respond_to?(:permit)  # convert ActionController::Parameters if given
+      url_options = url_options.merge(:order => new_sort)
 
       options[:as] = raw(options[:as]) if defined?(RailsXss)
 

--- a/spec/unit/rails_helper_spec.rb
+++ b/spec/unit/rails_helper_spec.rb
@@ -92,4 +92,24 @@ describe ScopedSearch::RailsHelper do
     params[:order] = "field DESC"
     sort("field")
   end
+
+  context 'with ActionController::Parameters' do
+    let(:ac_params) { double('ActionController::Parameters') }
+
+    it "should call to_h on passed params object" do
+      should_receive(:url_for).with(
+        "controller" => "resources",
+        "action" => "search",
+        "walrus" => "unicorns",
+        "order" => "field ASC"
+      ).and_return("/example")
+
+      params[:walrus] = "unicorns"
+
+      ac_params.should_receive(:respond_to?).with(:permit).and_return(true)
+      ac_params.should_receive(:to_h).and_return(params)
+
+      sort("field", {}, {}, ac_params)
+    end
+  end
 end


### PR DESCRIPTION
On Rails 5, passing `params` directly into `url_for` results in:

    ActionView::Template::Error (Attempting to generate a URL from
    non-sanitized request parameters! An attacker can inject malicious
    data into the generated URL, such as changing the host. Whitelist
    and sanitize passed parameters to be secure.):

The url_options/params is now parameterised so the user can pass a
filtered list of current URL options to the helper. If the default
`params` is used or an AC::Parameters object is passed, it's converted
to a hash of filtered parameters.