### PR TITLE
Prefer distinct over uniq on AR scopes on Rails 4+

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -178,7 +178,7 @@ module ScopedSearch
         .where(value_conditions(field_name, val))
         .select(field_name)
         .limit(20)
-        .uniq
+        .send(scope_distinct_method)
         .map(&field.key_field)
         .compact
         .map { |f| "#{name}.#{f} " }
@@ -205,10 +205,15 @@ module ScopedSearch
         .where(value_conditions(field.quoted_field, val))
         .select(field.quoted_field)
         .limit(20)
-        .uniq
+        .send(scope_distinct_method)
         .map(&field.field)
         .compact
         .map { |v| v.to_s =~ /\s/ ? "\"#{v}\"" : v }
+    end
+
+    # distinct is present on Rails 4.0 and higher, use uniq for 3.2
+    def scope_distinct_method
+      ActiveRecord::VERSION::MAJOR >= 4 ? :distinct : :uniq
     end
 
     def completer_scope(field)


### PR DESCRIPTION
uniq is deprecated in Rails 5.0, and will be removed in 5.1.