### PR TITLE
Remove Ruby 1.9 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ script:
 - bundle exec rake
 
 rvm:
-- "1.9"
 - "2.0"
 - "2.1"
 - "2.2.2"
@@ -33,8 +32,6 @@ matrix:
     - rvm: jruby-head
     - rvm: jruby-19mode
   exclude:
-    - rvm: "1.9"
-      gemfile: Gemfile.activerecord50
     - rvm: "2.0"
       gemfile: Gemfile.activerecord50
     - rvm: "2.1"

--- a/Gemfile.activerecord32
+++ b/Gemfile.activerecord32
@@ -10,7 +10,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.5'
   gem 'mysql2', '~> 0.3.11'
-  gem 'pg'
+  gem 'pg', '~> 0.11'
 end

--- a/Gemfile.activerecord40
+++ b/Gemfile.activerecord40
@@ -10,7 +10,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'mysql2', '~> 0.3.11'
-  gem 'pg'
+  gem 'pg', '~> 0.11'
 end

--- a/Gemfile.activerecord41
+++ b/Gemfile.activerecord41
@@ -10,7 +10,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'mysql2', '~> 0.3.11'
-  gem 'pg'
+  gem 'pg', '~> 0.11'
 end

--- a/Gemfile.activerecord42
+++ b/Gemfile.activerecord42
@@ -10,7 +10,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3'
-  gem 'mysql2', '~> 0.3.11'
-  gem 'pg'
+  gem 'sqlite3', '~> 1.3.6'
+  gem 'mysql2', '>= 0.3.13', '< 0.5'
+  gem 'pg', '~> 0.15'
 end

--- a/Gemfile.activerecord50
+++ b/Gemfile.activerecord50
@@ -10,7 +10,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3'
-  gem 'mysql2', '~> 0.3.11'
-  gem 'pg'
+  gem 'sqlite3', '~> 1.3.6'
+  gem 'mysql2', '>= 0.3.18', '< 0.5'
+  gem 'pg', '~> 0.18'
 end


### PR DESCRIPTION
Also matches the gem versions expected by ActiveRecord adapters (`grep ^gem lib/active_record/connection_adapters/*.rb`), including the newer, supported mysql2 0.4 series in newer AR versions.