### PR TITLE
Fixes wrong association on through conditions

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -271,7 +271,7 @@ module ScopedSearch
 
       # primary and foreign keys + optional condition for the many to middle join
       pk1, fk1   = field.reflection_keys(definition.reflection_by_name(many_class, through))
-      condition1 = field.reflection_conditions(definition.reflection_by_name(field.klass, many_table_name))
+      condition1 = field.reflection_conditions(definition.reflection_by_name(field.klass, middle_table_name))
 
       # primary and foreign keys + optional condition for the endpoint to middle join
       middle_table_association = find_has_many_through_association(field, through) || middle_table_name


### PR DESCRIPTION
as a reproducer, you can use Foreman and it's issue described in http://projects.theforeman.org/issues/17364

in general, condition that's being searched is being searched in wrong reflection. If the condition from this different reflection defines some condition on its column e.g. type (polymorphic association on its type) it adds this field to resulting WHERE but the column does not exist anywhere in the relation.