### PR TITLE
Don't eager load data on :has_many relations

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -311,7 +311,7 @@ module ScopedSearch
           klass_table_name = relation ? "#{klass.table_name}_#{num}" : klass.table_name
           return "#{connection.quote_table_name(klass_table_name)}.#{connection.quote_column_name(field.to_s)}"
         elsif relation
-          yield(:include, relation)
+          yield(:include, relation) unless definition.reflection_by_name(definition.klass, relation).macro == :has_many && [:eq, :ne, :gt, :gte, :lt, :lte].include?(operator)
         end
         column_name = connection.quote_table_name(klass.table_name.to_s) + "." + connection.quote_column_name(field.to_s)
         column_name = "(#{column_name} >> #{offset*word_size} & #{2**word_size - 1})" if offset

--- a/spec/integration/relation_querying_spec.rb
+++ b/spec/integration/relation_querying_spec.rb
@@ -142,6 +142,9 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         ::Goo.search_for('too another').length.should == 0
       end
 
+      it "shouldn't eager load extra data for related table" do
+        ::Goo.search_for('related = bar').includes_values.length.should == 0
+      end
     end
 
     context 'querying a :has_one relation' do
@@ -427,7 +430,7 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         # Create some tables
         ActiveRecord::Migration.create_table(:zaps) { |t| t.integer :moo_id; t.integer :paz_id }
         ActiveRecord::Migration.create_table(:pazs) { |t| t.string :related }
-        ActiveRecord::Migration.create_table(:moos) { |t| t.string :foo }   
+        ActiveRecord::Migration.create_table(:moos) { |t| t.string :foo }
 
         # The related classes
         class Zap < ActiveRecord::Base; belongs_to :paz; belongs_to :moo; end
@@ -532,7 +535,7 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         # Create some tables with namespaces
         ActiveRecord::Migration.create_table(:zan_mars) { |t| t.integer :koo_id; t.integer :baz_id }
         ActiveRecord::Migration.create_table(:zan_bazs) { |t| t.string :related }
-        ActiveRecord::Migration.create_table(:zan_koos) { |t| t.string :foo }   
+        ActiveRecord::Migration.create_table(:zan_koos) { |t| t.string :foo }
 
         # The related classes
         module Zan; class Mar < ActiveRecord::Base; belongs_to :baz; belongs_to :koo; self.table_name = "zan_mars"; end; end


### PR DESCRIPTION
When generating a query to search on a column in a related table that
has a has_many relationship, scoped search uses an inner query to get
the ids of the records to return (using `primary_key IN (SELECT...)`)
when the operator is a comparison operator (eq, ne, gt, etc.).

Therefore, the related table doesn't need to be joined for the query to
return the correct result, reducing the complexity of the query and the
size of the results returned in these cases.