### PR TITLE
STI support: searching on subclasses, parent definition inheritance

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -8,6 +8,9 @@ Please add an entry to the "Unreleased changes" section in your pull requests.
 
 - Support calling `search_for` on an STI subclass, returning only records of the
   subclass type.
+- Inherited search definitions: when defining search fields on both STI parents
+  and subclasses, the subclass can now be searched on all fields, including
+  those inherited from the parent. Only works for STI classes.
 
 === Version 4.0.0
 

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -6,7 +6,8 @@ Please add an entry to the "Unreleased changes" section in your pull requests.
 
 === Unreleased changes
 
-*Nothing yet*
+- Support calling `search_for` on an STI subclass, returning only records of the
+  subclass type.
 
 === Version 4.0.0
 

--- a/lib/scoped_search.rb
+++ b/lib/scoped_search.rb
@@ -24,9 +24,14 @@ module ScopedSearch
 
     # Export the scoped_search method fo defining the search options.
     # This method will create a definition instance for the class if it does not yet exist,
-    # and use the object as block argument and retun value.
+    # or if a parent definition exists then it will create a new one inheriting it,
+    # and use the object as block argument and return value.
     def scoped_search(*definitions)
       self.scoped_search_definition ||= ScopedSearch::Definition.new(self)
+      unless self.scoped_search_definition.klass == self  # inheriting the parent
+        self.scoped_search_definition = ScopedSearch::Definition.new(self)
+      end
+
       definitions.each do |definition|
         if definition[:on].kind_of?(Array)
           definition[:on].each { |field| self.scoped_search_definition.define(definition.merge(:on => field)) }

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -278,11 +278,12 @@ module ScopedSearch
     # Registers the search_for named scope within the class that is used for searching.
     def register_named_scope! # :nodoc
       definition = self
-      @klass.scope(:search_for, proc { |query, options|
-        klass = definition.klass
+      @klass.define_singleton_method(:search_for) do |query = '', options = {}|
+        # klass may be different to @klass if the scope is called on a subclass
+        klass = self
 
         search_scope = klass.all
-        find_options = ScopedSearch::QueryBuilder.build_query(definition, query || '', options || {})
+        find_options = ScopedSearch::QueryBuilder.build_query(definition, query || '', options)
         search_scope = search_scope.where(find_options[:conditions])   if find_options[:conditions]
         search_scope = search_scope.includes(find_options[:include])   if find_options[:include]
         search_scope = search_scope.joins(find_options[:joins])        if find_options[:joins]
@@ -290,7 +291,7 @@ module ScopedSearch
         search_scope = search_scope.references(find_options[:include]) if find_options[:include]
 
         search_scope
-      })
+      end
     end
 
     # Registers the complete_for method within the class that is used for searching.

--- a/spec/integration/api_spec.rb
+++ b/spec/integration/api_spec.rb
@@ -21,13 +21,6 @@ describe ScopedSearch, "API" do
     ScopedSearch::RSpec::Database.close_connection
   end
 
-  context 'for unprepared ActiveRecord model' do
-
-    it "should respond to :scoped_search to setup scoped_search for the model" do
-      Class.new(ActiveRecord::Base).should respond_to(:scoped_search)
-    end
-  end
-
   context 'for a prepared ActiveRecord model' do
 
     before(:all) do
@@ -44,8 +37,22 @@ describe ScopedSearch, "API" do
       @class.should respond_to(:search_for)
     end
 
-    it "should return a ActiveRecord::Relation instance" do
+    it "should return a ActiveRecord::Relation instance with no arguments" do
+      @class.search_for.should be_a(ActiveRecord::Relation)
+    end
+
+    it "should return a ActiveRecord::Relation instance with one argument" do
       @class.search_for('query').should be_a(ActiveRecord::Relation)
+    end
+
+    it "should return a ActiveRecord::Relation instance with two arguments" do
+      @class.search_for('query', {}).should be_a(ActiveRecord::Relation)
+    end
+
+    it "should respect existing scope" do
+      @class.create! field: 'a'
+      record = @class.create! field: 'ab'
+      @class.where(field: 'ab').search_for('field ~ a').should eq([record])
     end
   end
 end

--- a/spec/integration/scope_spec.rb
+++ b/spec/integration/scope_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+# These specs will run on all databases that are defined in the spec/database.yml file.
+# Comment out any databases that you do not have available for testing purposes if needed.
+ScopedSearch::RSpec::Database.test_databases.each do |db|
+
+  describe ScopedSearch, "using a #{db} database" do
+
+    before(:all) do
+      ScopedSearch::RSpec::Database.establish_named_connection(db)
+
+      @class = ScopedSearch::RSpec::Database.create_model(:field => :string) do |klass|
+        klass.scoped_search :on => :field
+      end
+    end
+
+    after(:all) do
+      ScopedSearch::RSpec::Database.drop_model(@class)
+      ScopedSearch::RSpec::Database.close_connection
+    end
+
+    context '.search_for' do
+      it "should respect existing scope" do
+        @class.create! field: 'a'
+        record = @class.create! field: 'ab'
+        @class.where(field: 'ab').search_for('field ~ a').should eq([record])
+      end
+    end
+  end
+end

--- a/spec/integration/sti_querying_spec.rb
+++ b/spec/integration/sti_querying_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+# These specs will run on all databases that are defined in the spec/database.yml file.
+# Comment out any databases that you do not have available for testing purposes if needed.
+ScopedSearch::RSpec::Database.test_databases.each do |db|
+
+  describe ScopedSearch, "using a #{db} database" do
+
+    before(:all) do
+      ScopedSearch::RSpec::Database.establish_named_connection(db)
+
+      @parent_class = ScopedSearch::RSpec::Database.create_model(int: :integer, type: :string) do |klass|
+        klass.scoped_search on: :int
+      end
+      @subclass1 = ScopedSearch::RSpec::Database.create_sti_model(@parent_class)
+      @subclass2 = ScopedSearch::RSpec::Database.create_sti_model(@parent_class)
+    end
+
+    after(:all) do
+      ScopedSearch::RSpec::Database.drop_model(@parent_class)
+      ScopedSearch::RSpec::Database.close_connection
+    end
+
+    context 'querying STI parent and subclasses' do
+      before(:all) do
+        @record1 = @subclass1.create!(int: 7)
+        @record2 = @subclass2.create!(int: 9)
+      end
+
+      after(:all) do
+        @record1.destroy
+        @record2.destroy
+      end
+
+      it "should find a record using the parent class" do
+        @parent_class.search_for('int = 7').should eq([@record1])
+      end
+
+      it "should find a record using the subclass" do
+        @subclass1.search_for('int = 7').should eq([@record1])
+      end
+
+      it "should not find a record using the wrong subclass" do
+        @subclass2.search_for('int = 7').should eq([])
+      end
+    end
+  end
+end

--- a/spec/integration/sti_querying_spec.rb
+++ b/spec/integration/sti_querying_spec.rb
@@ -9,29 +9,35 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
     before(:all) do
       ScopedSearch::RSpec::Database.establish_named_connection(db)
 
-      @parent_class = ScopedSearch::RSpec::Database.create_model(int: :integer, type: :string) do |klass|
+      @related_class = ScopedSearch::RSpec::Database.create_model(int: :integer)
+
+      @parent_class = ScopedSearch::RSpec::Database.create_model(int: :integer, type: :string, related_id: :integer) do |klass|
         klass.scoped_search on: :int
       end
       @subclass1 = ScopedSearch::RSpec::Database.create_sti_model(@parent_class)
-      @subclass2 = ScopedSearch::RSpec::Database.create_sti_model(@parent_class)
+      @subclass2 = ScopedSearch::RSpec::Database.create_sti_model(@parent_class) do |klass|
+        klass.belongs_to @related_class.table_name.to_sym, foreign_key: :related_id
+        klass.scoped_search on: :int, rename: :other_int
+        klass.scoped_search relation: @related_class.table_name, on: :int, rename: :related_int
+      end
+
+      @related_class.has_many @subclass1.table_name.to_sym
+
+      @record1 = @subclass1.create!(int: 7)
+      @related_record1 = @related_class.create!(int: 42)
+      @record2 = @subclass2.create!(int: 9, related_id: @related_record1.id)
     end
 
     after(:all) do
+      @record1.destroy
+      @record2.destroy
+
       ScopedSearch::RSpec::Database.drop_model(@parent_class)
+      ScopedSearch::RSpec::Database.drop_model(@related_class)
       ScopedSearch::RSpec::Database.close_connection
     end
 
     context 'querying STI parent and subclasses' do
-      before(:all) do
-        @record1 = @subclass1.create!(int: 7)
-        @record2 = @subclass2.create!(int: 9)
-      end
-
-      after(:all) do
-        @record1.destroy
-        @record2.destroy
-      end
-
       it "should find a record using the parent class" do
         @parent_class.search_for('int = 7').should eq([@record1])
       end
@@ -42,6 +48,35 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
 
       it "should not find a record using the wrong subclass" do
         @subclass2.search_for('int = 7').should eq([])
+        @subclass2.search_for('int = 9').should eq([@record2])
+      end
+
+      it "parent should not recognize field from subclass" do
+        lambda { @parent_class.search_for('related_int = 9') }.should raise_error(ScopedSearch::QueryNotSupported, "Field 'related_int' not recognized for searching!")
+      end
+
+      it "should autocomplete int field on parent" do
+        @parent_class.complete_for('').should contain(' int ')
+      end
+
+      it "should autocomplete int field on subclass" do
+        @subclass1.complete_for('').should contain(' int ')
+      end
+
+      it "should autocomplete int, other_int, related_int fields on subclass" do
+        @subclass2.complete_for('').should contain(' int ')
+        @subclass2.complete_for('').should contain(' other_int ')
+        @subclass2.complete_for('').should contain(' related_int ')
+      end
+    end
+
+    context 'querying definition on STI subclass' do
+      it "should find a record using subclass definition" do
+        @subclass2.search_for('other_int = 9').should eq([@record2])
+      end
+
+      it "should find a record via relation" do
+        @subclass2.search_for('related_int = 42').should eq([@record2])
       end
     end
   end

--- a/spec/lib/database.rb
+++ b/spec/lib/database.rb
@@ -58,6 +58,13 @@ module ScopedSearch::RSpec::Database
     return klass
   end
 
+  def self.create_sti_model(parent)
+    klass_name = "#{parent.table_name}_#{rand}".gsub(/\W/, '')
+    klass = ScopedSearch::RSpec::Database.const_set(klass_name.classify, Class.new(parent))
+    yield(klass) if block_given?
+    return klass
+  end
+
   def self.drop_model(klass)
     klass.constants.grep(/\AHABTM_/).each do |habtm_class|
       ActiveRecord::Migration.drop_table(klass.const_get(habtm_class).table_name)

--- a/spec/lib/mocks.rb
+++ b/spec/lib/mocks.rb
@@ -10,7 +10,14 @@ module ScopedSearch::RSpec::Mocks
     ar_mock.stub(:scope).with(:search_for, anything)
     ar_mock.stub(:connection).and_return(mock_database_connection)
     ar_mock.stub(:ancestors).and_return([ActiveRecord::Base])
+    ar_mock.stub(:superclass).and_return(ActiveRecord::Base)
     ar_mock.stub(:columns_hash).and_return({'existing' => double('column')})
+    return ar_mock
+  end
+
+  def mock_activerecord_subclass(parent)
+    ar_mock = mock_activerecord_class
+    ar_mock.stub(:superclass).and_return(parent)
     return ar_mock
   end
 

--- a/spec/unit/definition_spec.rb
+++ b/spec/unit/definition_spec.rb
@@ -62,13 +62,13 @@ describe ScopedSearch::Definition do
 
   describe '#initialize' do
     it "should create the named scope when" do
-      @klass.should_receive(:scope).with(:search_for, instance_of(Proc))
       ScopedSearch::Definition.new(@klass)
+      @klass.should respond_to(:search_for)
     end
 
     it "should not create the named scope if it already exists" do
       @klass.stub(:search_for)
-      @klass.should_not_receive(:scope)
+      @klass.should_not_receive(:define_singleton_method)
       ScopedSearch::Definition.new(@klass)
     end
   end


### PR DESCRIPTION
Two distinct fixes to add Single Table Inheritance (STI) support:

---

**Use current class from scope when searching, not the definition class**

With an STI parent and subclass, calling `Parent.where` within a named
scope (i.e. `search_for`) in Rails 5+ now correctly returns all parent
and subclass records. When calling `Subclass.search_for`, this would
return unexpected results from other subclasses.

Querying the class that the scope was called on ensures the result is
limited to that class, restoring very basic STI support.

Fixes #112

---

**Definitions inherit fields from STI parent class too**

When `scoped_search` is called on a parent and then its subclass, a new
`Definition` will be created and stored on the subclass that inherits
and merges fields with its parent.

The named scope will only be registered on the parent, but the most
specific definition from the subclass is used when the scope is called.
This allows `Subclass.search_for` to support both parent and subclass
fields, but `Parent.search_for` to only support parent fields.

Previously fields registered on the subclass may have used the parent's
definition causing errors finding relations as the wrong class was used.

Only works with STI parents/subclasses, not regular inheritance or
abstract classes as table and column information can safely be retrieved
against either the parent or subclass with STI.

Fixes #135

---

I have a further fix to support inheritance with abstract classes, but it was more complex with more refactoring required so I'll submit that after this has been completed.
