### PR TITLE
Fixes #162 - Allow searching by future relative dates

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -229,12 +229,14 @@ module ScopedSearch
       options << '"2 hours ago"'
       options << 'Today'
       options << 'Yesterday'
+      options << 'Tomorrow'
       options << 2.days.ago.strftime('%A')
       options << 3.days.ago.strftime('%A')
       options << 4.days.ago.strftime('%A')
       options << 5.days.ago.strftime('%A')
       options << '"6 days ago"'
       options << 7.days.ago.strftime('"%b %d,%Y"')
+      options << '2 weeks from now'
       options
     end
 

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -241,13 +241,16 @@ module ScopedSearch
     end
 
     # Try to parse a string as a datetime.
-    # Supported formats are Today, Yesterday, Sunday, '1 day ago', '2 hours ago', '3 months ago','Jan 23, 2004'
+    # Supported formats are Today, Yesterday, Sunday, '1 day ago', '2 hours ago', '3 months ago', '4 weeks from now', 'Jan 23, 2004'
     # And many more formats that are documented in Ruby DateTime API Doc.
     def parse_temporal(value)
       return Date.current if value =~ /\btoday\b/i
       return 1.day.ago.to_date if value =~ /\byesterday\b/i
+      return 1.day.from_now.to_date if value =~ /\btomorrow\b/i
       return (eval($1.strip.gsub(/\s+/,'.').downcase)).to_datetime if value =~ /\A\s*(\d+\s+\b(?:hours?|minutes?)\b\s+\bago)\b\s*\z/i
       return (eval($1.strip.gsub(/\s+/,'.').downcase)).to_date     if value =~ /\A\s*(\d+\s+\b(?:days?|weeks?|months?|years?)\b\s+\bago)\b\s*\z/i
+      return (eval($1.strip.gsub(/from\s+now/i,'from_now').gsub(/\s+/,'.').downcase)).to_datetime if value =~ /\A\s*(\d+\s+\b(?:hours?|minutes?)\b\s+\bfrom\s+now)\b\s*\z/i
+      return (eval($1.strip.gsub(/from\s+now/i,'from_now').gsub(/\s+/,'.').downcase)).to_date     if value =~ /\A\s*(\d+\s+\b(?:days?|weeks?|months?|years?)\b\s+\bfrom\s+now)\b\s*\z/i
       DateTime.parse(value, true) rescue nil
     end
 

--- a/spec/integration/ordinal_querying_spec.rb
+++ b/spec/integration/ordinal_querying_spec.rb
@@ -166,6 +166,8 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         @curent_record = @class.create!(:timestamp => Time.current, :date => Date.current)
         @hour_ago_record = @class.create!(:timestamp => Time.current - 1.hour, :date => Date.current)
         @day_ago_record = @class.create!(:timestamp => Time.current - 1.day, :date => Date.current - 1.day)
+        @tomorrow_record = @class.create!(:timestamp => Time.current + 1.day, :date => Date.current + 1.day)
+        @week_from_now_record = @class.create!(:timestamp => Time.current + 1.week, :date => Date.current + 1.week)
         @month_ago_record = @class.create!(:timestamp => Time.current - 1.month, :date => Date.current - 1.month)
         @year_ago_record = @class.create!(:timestamp => Time.current - 1.year, :date => Date.current - 1.year)
       end
@@ -174,6 +176,8 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         @curent_record.destroy
         @hour_ago_record.destroy
         @day_ago_record.destroy
+        @tomorrow_record.destroy
+        @week_from_now_record.destroy
         @month_ago_record.destroy
         @year_ago_record.destroy
       end
@@ -184,6 +188,10 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
 
       it "should accept Yesterday as date format" do
         @class.search_for('date = yesterday').length.should == 1
+      end
+
+      it "should accept Tomorrow as date format" do
+        @class.search_for('date = tomorrow').length.should == 1
       end
 
       it "should find all timestamps and date from today using the = operator" do
@@ -198,16 +206,24 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         @class.search_for('date < "2 days ago"').length.should == 2
       end
 
-       it "should accept 3 hours ago as date format" do
-        @class.search_for('timestamp > "3 hours ago"').length.should == 2
-       end
+      it "should accept 3 hours ago as date format" do
+        @class.search_for('timestamp > "3 hours ago"').length.should == 4
+      end
 
-       it "should accept 1 month ago as date format" do
-        @class.search_for('date > "1 month ago"').length.should == 3
-       end
+      it "should accept 1 week from now as date format" do
+        @class.search_for('date < "1 week from now"').length.should == 6
+      end
+
+      it "should accept 1 month ago as date format" do
+        @class.search_for('date > "1 month ago"').length.should == 5
+      end
+
+      it "should accept 1 month from now as date format" do
+        @class.search_for('date < "1 month from now"').length.should == 7
+      end
 
       it "should accept 1 year ago as date format" do
-        @class.search_for('date > "1 year ago"').length.should == 4
+        @class.search_for('date > "1 year ago"').length.should == 6
       end
 
     end


### PR DESCRIPTION
Date fields can now be searched using future relative time phrases, such
as 'tomorrow', '2 weeks from now' and so on.