### PR TITLE
Replace private tag_options call with public content_tag helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'actionview'
 gem 'activerecord'
+
+gem 'nokogiri', '~> 1.6.0' if RUBY_VERSION.start_with?('2.0')
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/Gemfile.activerecord42
+++ b/Gemfile.activerecord42
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'actionview', '~> 4.2.0'
 gem 'activerecord', '~> 4.2.0'
+
+gem 'nokogiri', '~> 1.6.0' if RUBY_VERSION.start_with?('2.0')
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/Gemfile.activerecord50
+++ b/Gemfile.activerecord50
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'actionview', '~> 5.0.0'
 gem 'activerecord', '~> 5.0.0'
 
 platforms :jruby do

--- a/Gemfile.activerecord51
+++ b/Gemfile.activerecord51
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'actionview', '>= 5.1.0.beta1', '< 5.2'
 gem 'activerecord', '>= 5.1.0.beta1', '< 5.2'
 
 platforms :jruby do

--- a/lib/scoped_search/rails_helper.rb
+++ b/lib/scoped_search/rails_helper.rb
@@ -47,10 +47,10 @@ module ScopedSearch
       unless selected_sort.nil?
         css_classes = html_options[:class] ? html_options[:class].split(" ") : []
         if selected_sort == ascend
-          as = "&#9650;&nbsp;#{as}"
+          as = "&#9650;&nbsp;".html_safe + as
           css_classes << "ascending"
         else
-          as = "&#9660;&nbsp;#{as}"
+          as = "&#9660;&nbsp;".html_safe + as
           css_classes << "descending"
         end
         html_options[:class] = css_classes.join(" ")
@@ -61,13 +61,7 @@ module ScopedSearch
 
       as = raw(as) if defined?(RailsXss)
 
-      a_link(as, html_escape(url_for(url_options)),html_options)
-    end
-
-    def a_link(name, href, html_options)
-      tag_options = tag_options(html_options)
-      link = "<a href=\"#{href}\"#{tag_options}>#{name}</a>"
-      return link.respond_to?(:html_safe) ? link.html_safe : link
+      content_tag(:a, as, html_options.merge(href: url_for(url_options)))
     end
   end
 end

--- a/spec/integration/rails_helper_spec.rb
+++ b/spec/integration/rails_helper_spec.rb
@@ -62,32 +62,21 @@ describe ScopedSearch::RailsHelper do
     sort("other")
   end
 
-  it "should set :href on anchor" do
+  it "should set :href and no :class on anchor" do
     should_receive(:url_for).and_return('/example')
-    should_receive(:content_tag).with(:a, 'Field', href: '/example')
-    sort("field")
-  end
-
-  it "should add no styling by default" do
-    should_receive(:url_for)
-    should_receive(:content_tag).with(:a, 'Field', hash_excluding(:class))
-    sort("field")
+    sort("field").should == '<a href="/example">Field</a>'
   end
 
   it "should add ascending style for current ascending sort order " do
-    should_receive(:url_for)
-    should_receive(:content_tag).with(:a, '&#9650;&nbsp;Field', hash_including(:class => 'ascending'))
-
+    should_receive(:url_for).and_return('/example')
     params[:order] = "field ASC"
-    sort("field")
+    sort("field").should == '<a class="ascending" href="/example">&#9650;&nbsp;Field</a>'
   end
 
   it "should add descending style for current descending sort order " do
-    should_receive(:url_for)
-    should_receive(:content_tag).with(:a, '&#9660;&nbsp;Field', hash_including(:class => 'descending'))
-
+    should_receive(:url_for).and_return('/example')
     params[:order] = "field DESC"
-    sort("field")
+    sort("field").should == '<a class="descending" href="/example">&#9660;&nbsp;Field</a>'
   end
 
   context 'with ActionController::Parameters' do

--- a/spec/integration/rails_helper_spec.rb
+++ b/spec/integration/rails_helper_spec.rb
@@ -1,19 +1,10 @@
 require "spec_helper"
+require "action_view"
 require "scoped_search/rails_helper"
-
-module ActionViewHelperStubs
-  def html_escape(str)
-    str
-  end
-
-  def tag_options(options)
-    ""
-  end
-end
 
 describe ScopedSearch::RailsHelper do
   include ScopedSearch::RailsHelper
-  include ActionViewHelperStubs
+  include ActionView::Helpers
 
   let(:params) { HashWithIndifferentAccess.new(:controller => "resources", :action => "search") }
 
@@ -71,15 +62,21 @@ describe ScopedSearch::RailsHelper do
     sort("other")
   end
 
+  it "should set :href on anchor" do
+    should_receive(:url_for).and_return('/example')
+    should_receive(:content_tag).with(:a, 'Field', href: '/example')
+    sort("field")
+  end
+
   it "should add no styling by default" do
     should_receive(:url_for)
-    should_receive(:a_link).with('Field', anything, hash_excluding(:class))
+    should_receive(:content_tag).with(:a, 'Field', hash_excluding(:class))
     sort("field")
   end
 
   it "should add ascending style for current ascending sort order " do
     should_receive(:url_for)
-    should_receive(:a_link).with('&#9650;&nbsp;Field', anything, hash_including(:class => 'ascending'))
+    should_receive(:content_tag).with(:a, '&#9650;&nbsp;Field', hash_including(:class => 'ascending'))
 
     params[:order] = "field ASC"
     sort("field")
@@ -87,7 +84,7 @@ describe ScopedSearch::RailsHelper do
 
   it "should add descending style for current descending sort order " do
     should_receive(:url_for)
-    should_receive(:a_link).with('&#9660;&nbsp;Field', anything, hash_including(:class => 'descending'))
+    should_receive(:content_tag).with(:a, '&#9660;&nbsp;Field', hash_including(:class => 'descending'))
 
     params[:order] = "field DESC"
     sort("field")


### PR DESCRIPTION
The private `tag_options` method was refactored away in
rails/rails@a65a3bd. Adds ActionView to spec to make all HTML-safe
extensions available.