### PR TITLE
Fix validations on :in operator

### DIFF
--- a/Gemfile.activerecord51
+++ b/Gemfile.activerecord51
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'actionview', '>= 5.1.0.beta1', '< 5.2'
-gem 'activerecord', '>= 5.1.0.beta1', '< 5.2'
+gem 'actionview', '~> 5.1.0'
+gem 'activerecord', '~> 5.1.0'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -484,7 +484,11 @@ module ScopedSearch
           raise ScopedSearch::QueryNotSupported, "Field '#{lhs.value}' not recognized for searching!" unless field
 
           # see if the value passes user defined validation
-          validate_value(field, rhs.value)
+          if operator == :in
+            rhs.value.split(',').each { |v| validate_value(field, v) }
+          else
+            validate_value(field, rhs.value)
+          end
 
           builder.sql_test(field, operator, rhs.value,lhs.value, &block)
         end

--- a/spec/unit/query_builder_spec.rb
+++ b/spec/unit/query_builder_spec.rb
@@ -47,6 +47,22 @@ describe ScopedSearch::QueryBuilder do
     lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field = test_val') }.should raise_error(ScopedSearch::QueryNotSupported)
   end
 
+  it "should validate value if validator selected" do
+    field = double('field')
+    field.stub(:only_explicit).and_return(true)
+    field.stub(:field).and_return(:test_field)
+    field.stub(:ext_method).and_return(nil)
+    field.stub(:key_field).and_return(nil)
+    field.stub(:set?).and_return(false)
+    field.stub(:to_sql).and_return('')
+    field.stub(:validator).and_return(->(value) { value =~ /^\d+$/ })
+
+    @definition.stub(:field_by_name).and_return(field)
+
+    lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field ^ (1,2)') }.should_not raise_error
+    lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field ^ (1,a)') }.should raise_error(ScopedSearch::QueryNotSupported)
+  end
+
   it "should display custom error from validator" do
     field = double('field')
     field.stub(:only_explicit).and_return(true)


### PR DESCRIPTION
The problem is when you specify e.g. numeric validator and the do something like

`Model.search_for("numeric_param ^ (1,2)")`, it validates the whole value. For :in operator we need to split the value by comma and validate each one separately.