### PR TITLE
Don't swallow errors in external methods

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -402,7 +402,11 @@ module ScopedSearch
 
       def to_ext_method_sql(key, operator, value, &block)
         raise ScopedSearch::QueryNotSupported, "'#{definition.klass}' doesn't respond to '#{ext_method}'" unless definition.klass.respond_to?(ext_method)
-        conditions = definition.klass.send(ext_method.to_sym,key, operator, value) rescue {}
+        begin
+          conditions = definition.klass.send(ext_method.to_sym, key, operator, value) 
+        rescue StandardError => e
+          raise ScopedSearch::QueryNotSupported, "external method '#{ext_method}' failed with error: #{e}"
+        end
         raise ScopedSearch::QueryNotSupported, "external method '#{ext_method}' should return hash" unless conditions.kind_of?(Hash)
         sql = ''
         conditions.map do |notification, content|

--- a/spec/unit/query_builder_spec.rb
+++ b/spec/unit/query_builder_spec.rb
@@ -99,9 +99,9 @@ describe ScopedSearch::QueryBuilder do
       lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field = test_val') }.should raise_error(ScopedSearch::QueryNotSupported, /doesn't respond to 'ext_test'/)
     end
 
-    it "should ignore exceptions" do
+    it "should raise error when method raises exception" do
       klass.should_receive(:ext_test).and_raise('test')
-      ScopedSearch::QueryBuilder.build_query(@definition, 'test_field = test_val').should eq({})
+      lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field = test_val') }.should raise_error(ScopedSearch::QueryNotSupported, /failed with error: test/)
     end
   end
 end


### PR DESCRIPTION
Currently, if an ext_method raises an error, it is silently captured and
the query is executed with no conditions. This PR will change it so that
and such exception is caught and an informative error is raised.