### PR TITLE
Add an "onClear" option to scopedSearch

### DIFF
--- a/app/assets/javascripts/scoped_search.js
+++ b/app/assets/javascripts/scoped_search.js
@@ -25,6 +25,7 @@ $.widget( "custom.catcomplete", $.ui.autocomplete, {
     var options = arguments[0] || {};
     $(this).each(function(i,el){
       var target = $(el);
+      var clearFn = options.onClear || function(){ target.val(''); };
 
       target.catcomplete({
         source: options.source || function( request, response ) {
@@ -50,6 +51,6 @@ $.widget( "custom.catcomplete", $.ui.autocomplete, {
         $(this).catcomplete( target.attr('id'));
       });
       target.after('<a class="autocomplete-clear" tabindex="-1" title="Clear">&times;</a>')
-      target.next().on("click",function(){ target.val(''); })
+      target.next().on("click", clearFn)
     })
   };


### PR DESCRIPTION
`scoped search`'s clear function sets an empty value by default.
However, there are cases where one would like to customize that behavior.
For example, set a different clear value (e.g. one space).

In this patch, I introduce a way to do that by setting the `onClear` option.

In the following example, we confirm that the user wants to clean the search box before cleaning it:

```javascript
$(input).scopedSearch({'onClear': function(event) {
  confirm("are you sure?") ? $(input).value('') : null
});
```

ping @ohadlevy
The reason I push this change is to fix http://projects.theforeman.org/issues/22698
PTAL and tell me WDYT. If you thought about a better way, let me know.