### PR TITLE
Don't check column type when ext_method

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -6,7 +6,7 @@ Please add an entry to the "Unreleased changes" section in your pull requests.
 
 === Unreleased changes
 
-*Nothing yet*
+- Bugfix related to LIKE queries on virtual fields (#178)
 
 === Version 4.1.3
 

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -113,7 +113,7 @@ module ScopedSearch
     # By default, it will simply look up the correct SQL operator in the SQL_OPERATORS
     # hash, but this can be overridden by a database adapter.
     def sql_operator(operator, field)
-      raise ScopedSearch::QueryNotSupported, "the operator '#{operator}' is not supported for field type '#{field.type}'" if [:like, :unlike].include?(operator) and !field.textual?
+      raise ScopedSearch::QueryNotSupported, "the operator '#{operator}' is not supported for field type '#{field.type}'" if !field.ext_method and [:like, :unlike].include?(operator) and !field.textual?
       SQL_OPERATORS[operator]
     end
 
@@ -554,7 +554,7 @@ module ScopedSearch
       # Switches out the default LIKE operator in the default <tt>sql_operator</tt>
       # method for ILIKE or @@ if full text searching is enabled.
       def sql_operator(operator, field)
-        raise ScopedSearch::QueryNotSupported, "the operator '#{operator}' is not supported for field type '#{field.type}'" if [:like, :unlike].include?(operator) and !field.textual?
+        raise ScopedSearch::QueryNotSupported, "the operator '#{operator}' is not supported for field type '#{field.type}'" if !field.ext_method and [:like, :unlike].include?(operator) and !field.textual?
         return '@@' if [:like, :unlike].include?(operator) && field.full_text_search
         case operator
           when :like   then 'ILIKE'

--- a/spec/unit/query_builder_spec.rb
+++ b/spec/unit/query_builder_spec.rb
@@ -90,6 +90,11 @@ describe ScopedSearch::QueryBuilder do
       ScopedSearch::QueryBuilder.build_query(@definition, 'test_field = test_val').should eq(include: ['test1'], joins: ['test2'])
     end
 
+    it "should support LIKE query even if database field doesn't exist" do
+      klass.should_receive(:ext_test).with('test_field', 'LIKE', 'test_val').and_return(conditions: 'field LIKE ?', parameter: ['%test_val%'])
+      ScopedSearch::QueryBuilder.build_query(@definition, 'test_field ~ test_val').should eq(conditions: ['(field LIKE ?)', '%test_val%'])
+    end
+
     it "should raise error when non-hash returned" do
       klass.should_receive(:ext_test).and_return('test')
       lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field = test_val') }.should raise_error(ScopedSearch::QueryNotSupported, /should return hash/)


### PR DESCRIPTION
Reviving #172 

This allows LIKE queries to work on definitions with ext_method but no corresponding database column.