### PR TITLE
Allow value mapping at search time

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -201,10 +201,16 @@ module ScopedSearch
       return complete_date_value if field.temporal?
       return complete_key_value(field, token, val) if field.key_field
 
+      special_values = field.special_values.select { |v| v =~ /\A#{val}/ }
+      special_values + complete_value_from_db(field, special_values, val)
+    end
+
+    def complete_value_from_db(field, special_values, val)
+      count = 20 - special_values.count
       completer_scope(field)
         .where(value_conditions(field.quoted_field, val))
         .select(field.quoted_field)
-        .limit(20)
+        .limit(count)
         .distinct
         .map(&field.field)
         .compact

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -52,6 +52,8 @@ module ScopedSearch
         raise ArgumentError, "Missing field or 'on' keyword argument" if on.nil?
         @field = on.to_sym
 
+        raise ArgumentError, "'special_values' must be an Array" unless special_values.kind_of?(Array)
+
         # Reserved Ruby keywords so access via kwargs instead, but deprecate them for future versions
         if kwargs.key?(:in)
           relation = kwargs.delete(:in)

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -17,7 +17,7 @@ module ScopedSearch
 
       attr_reader :definition, :field, :only_explicit, :relation, :key_relation, :full_text_search,
                   :key_field, :complete_value, :complete_enabled, :offset, :word_size, :ext_method, :operators,
-                  :validator
+                  :validator, :value_translation, :special_values
 
       # Initializes a Field instance given the definition passed to the
       # scoped_search call on the ActiveRecord-based model class.
@@ -42,7 +42,9 @@ module ScopedSearch
                      profile: nil,
                      relation: nil,
                      rename: nil,
+                     special_values: [],
                      validator: nil,
+                     value_translation: nil,
                      word_size: 1,
                      **kwargs)
 
@@ -77,8 +79,10 @@ module ScopedSearch
         @only_explicit    = !!only_explicit
         @operators        = operators
         @relation         = relation
+        @special_values   = special_values
         @validator        = validator
         @word_size        = word_size
+        @value_translation = value_translation
 
         # Store this field in the field array
         definition.define_field(rename || @field, self)

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -527,7 +527,7 @@ module ScopedSearch
         def validate_value(field, value)
           validator = field.validator
           if validator
-            valid = validator.call(value)
+            valid = field.special_values.include?(value) || validator.call(value)
             raise ScopedSearch::QueryNotSupported, "Value '#{value}' is not valid for field '#{field.field}'" unless valid
           end
         end

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -181,6 +181,14 @@ module ScopedSearch
       translated_value
     end
 
+    def map_value(field, value)
+      old_value = value
+      translator = field.value_translation
+      value = field.value_translation.call(value) if translator
+      raise ScopedSearch::QueryNotSupported, "Translation from any value to nil is not allowed, translated '#{old_value}'" if value.nil?
+      value
+    end
+
     # A 'set' is group of possible values, for example a status might be "on", "off" or "unknown" and the database representation
     # could be for example a numeric value. This method will validate the input and translate it into the database representation.
     def set_test(field, operator,value, &block)
@@ -219,7 +227,7 @@ module ScopedSearch
         return "#{field.to_sql(operator, &block)} #{self.sql_operator(operator, field)} ?"
 
       elsif [:in, :notin].include?(operator)
-        value.split(',').collect { |v| yield(:parameter, field.set? ? translate_value(field, v) : v.strip) }
+        value.split(',').collect { |v| yield(:parameter, map_value(field, field.set? ? translate_value(field, v) : v.strip)) }
         value = value.split(',').collect { "?" }.join(",")
         return "#{field.to_sql(operator, &block)} #{self.sql_operator(operator, field)} (#{value})"
 
@@ -231,6 +239,7 @@ module ScopedSearch
 
       elsif field.relation && definition.reflection_by_name(field.definition.klass, field.relation).macro == :has_many
         value = value.to_i if field.offset
+        value = map_value(field, value)
         yield(:parameter, value)
         connection = field.definition.klass.connection
         primary_key = "#{connection.quote_table_name(field.definition.klass.table_name)}.#{connection.quote_column_name(field.definition.klass.primary_key)}"
@@ -244,6 +253,7 @@ module ScopedSearch
 
       else
         value = value.to_i if field.offset
+        value = map_value(field, value)
         yield(:parameter, value)
         return "#{field.to_sql(operator, &block)} #{self.sql_operator(operator, field)} ?"
       end

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -184,7 +184,7 @@ module ScopedSearch
     def map_value(field, value)
       old_value = value
       translator = field.value_translation
-      value = field.value_translation.call(value) if translator
+      value = translator.call(value) if translator
       raise ScopedSearch::QueryNotSupported, "Translation from any value to nil is not allowed, translated '#{old_value}'" if value.nil?
       value
     end

--- a/spec/unit/query_builder_spec.rb
+++ b/spec/unit/query_builder_spec.rb
@@ -42,6 +42,7 @@ describe ScopedSearch::QueryBuilder do
     field.stub(:only_explicit).and_return(true)
     field.stub(:field).and_return(:test_field)
     field.stub(:validator).and_return(->(_value) { false })
+    field.stub(:special_values).and_return([])
 
     @definition.stub(:field_by_name).and_return(field)
 
@@ -59,6 +60,7 @@ describe ScopedSearch::QueryBuilder do
     field.stub(:to_sql).and_return('')
     field.stub(:validator).and_return(->(value) { value =~ /^\d+$/ })
     field.stub(:value_translation).and_return(nil)
+    field.stub(:special_values).and_return([])
 
     @definition.stub(:field_by_name).and_return(field)
 
@@ -72,6 +74,7 @@ describe ScopedSearch::QueryBuilder do
     field.stub(:only_explicit).and_return(true)
     field.stub(:field).and_return(:test_field)
     field.stub(:validator).and_return(->(_value) { raise ScopedSearch::QueryNotSupported, 'my custom message' })
+    field.stub(:special_values).and_return([])
 
     @definition.stub(:field_by_name).and_return(field)
 
@@ -83,18 +86,18 @@ describe ScopedSearch::QueryBuilder do
       ->(value) do
         if %w(a b c).include?(value)
           'good'
-        elsif value == 'd'
-          'okay'
         end
       end
     end
+    let(:special_values) { %w(a b c) }
     before do
       field = double('field')
       field.stub(:field).and_return(:test_field)
       field.stub(:key_field).and_return(nil)
       field.stub(:to_sql).and_return('test_field')
       [:virtual?, :set?, :temporal?, :relation, :offset].each { |key| field.stub(key).and_return(false) }
-      field.stub(:validator).and_return(->(value) { %w(a b c x).include?(value) })
+      field.stub(:validator).and_return(->(value) { value == 'x' }) # Nothing except for special_values and x is valid
+      field.stub(:special_values).and_return(special_values)
       field.stub(:value_translation).and_return(translator)
       @definition.stub(:field_by_name).and_return(field)
     end


### PR DESCRIPTION
Before this patch scoped_search allowed to define value mappings using the
complete_value, but these mappings were static. This patch introduces dynamic
value mapping which is resolved at search time, instead of at definition time.
This allows us to do searches like

```ruby
scoped_search on: :id,
  value_translation: ->(value) { value == 'current' ? User.current.id : value },
  validator: ->(value) { value =~ /\d+/ || value == 'current' },
  special_values: %w(current)
```

Please note the validations are run on the not yet translated input as provided
by the user.