### PR TITLE
Don't allow matching by first part of key before dot

### DIFF
--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -238,6 +238,9 @@ module ScopedSearch
       if field.nil?
         dotted = name.to_s.split('.')[0]
         field = fields[dotted.to_sym] unless dotted.blank?
+        if field && field.key_relation.nil?
+          return nil
+        end
       end
       field
     end

--- a/spec/integration/key_value_querying_spec.rb
+++ b/spec/integration/key_value_querying_spec.rb
@@ -33,6 +33,7 @@ require "spec_helper"
             has_many :keys, :through => :facts
 
             scoped_search :relation => :facts, :on => :value, :rename => :facts, :in_key => :keys, :on_key => :name, :complete_value => true
+            scoped_search :relation => :facts, :on => :value, :rename => 'myfacts.value', :aliases => ['prefixed', 'prefixed.value']
           end
           class ::MyItem < ::Item
           end
@@ -101,6 +102,20 @@ require "spec_helper"
 
         it "should find all bars with a fact name color and fact value gold of descendant class" do
           MyItem.search_for('facts.color = gold').first.name.should eql('barbary')
+        end
+
+        describe 'with prefixed aliases' do
+          it 'should search by the prefix' do
+            Item.search_for('prefixed = green').length.should == 1
+          end
+
+          it 'should search by the full length variant' do
+            Item.search_for('prefixed.value = green').length.should == 1
+          end
+
+          it 'should not search by just any key with common prefix' do
+            proc { Item.search_for('prefixed.something_which_is_not_defined = green') }.should raise_error(ScopedSearch::QueryNotSupported)
+          end
         end
       end
     end


### PR DESCRIPTION
With definition like:
```ruby
scoped_search :on => :a,
              :rename => 'something'
scoped_search :on => :b,
              :rename => 'something.else'
```

Searching for query like `something.custom_key = 5` would search on the `b` column for value `5`.