### PR TITLE
Support extra filter on auto complete value

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -208,6 +208,7 @@ module ScopedSearch
     def complete_value_from_db(field, special_values, val)
       count = 20 - special_values.count
       completer_scope(field)
+        .where(@options[:value_filter])
         .where(value_conditions(field.quoted_field, val))
         .select(field.quoted_field)
         .limit(count)


### PR DESCRIPTION
Example usage:

```ruby
@items = model.complete_for(params[:search], value_filter: {user_id: current_user.id})
```

In this particular app all records belong to a user and so this would allow limiting auto complete values to the values that belong to a user.