### PR TITLE
Abide "has_many ..., primary_key" overrides in relation searches.

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -229,12 +229,13 @@ module ScopedSearch
 
       if field.relation && definition.reflection_by_name(field.definition.klass, field.relation).macro == :has_many
         connection = field.definition.klass.connection
-        primary_key_col = field.definition.klass.reflections[field.relation.to_s]&.options[:primary_key] || field.definition.klass.primary_key
+        reflection = definition.reflection_by_name(field.definition.klass, field.relation)
+        primary_key_col = reflection.options[:primary_key] || field.definition.klass.primary_key
         primary_key = "#{connection.quote_table_name(field.definition.klass.table_name)}.#{connection.quote_column_name(primary_key_col)}"
-        key, join_table = if definition.reflection_by_name(field.definition.klass, field.relation).options.has_key?(:through)
+        key, join_table = if reflection.options.has_key?(:through)
                             [primary_key, has_many_through_join(field)]
                           else
-                            [connection.quote_column_name(field.reflection_keys(definition.reflection_by_name(field.definition.klass, field.relation))[1]),
+                            [connection.quote_column_name(field.reflection_keys(reflection)[1]),
                              connection.quote_table_name(field.klass.table_name)]
                           end
 

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -229,7 +229,8 @@ module ScopedSearch
 
       if field.relation && definition.reflection_by_name(field.definition.klass, field.relation).macro == :has_many
         connection = field.definition.klass.connection
-        primary_key = "#{connection.quote_table_name(field.definition.klass.table_name)}.#{connection.quote_column_name(field.definition.klass.primary_key)}"
+        primary_key_col = field.definition.klass.reflections[field.relation.to_s]&.options[:primary_key] || field.definition.klass.primary_key
+        primary_key = "#{connection.quote_table_name(field.definition.klass.table_name)}.#{connection.quote_column_name(primary_key_col)}"
         key, join_table = if definition.reflection_by_name(field.definition.klass, field.relation).options.has_key?(:through)
                             [primary_key, has_many_through_join(field)]
                           else

--- a/spec/integration/relation_querying_spec.rb
+++ b/spec/integration/relation_querying_spec.rb
@@ -720,5 +720,48 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         result.first.username.should == @usermat_1.username
       end
     end
+
+    context "querying on :has_many with primary key override" do
+
+      before do
+        ActiveRecord::Migration.create_table(:books) { |t| t.string :title; t.string :isbn }
+        ActiveRecord::Migration.create_table(:comments) { |t| t.string :comment; t.string :isbn }
+
+        class Book < ActiveRecord::Base
+          has_many :comments, foreign_key: 'isbn', primary_key: 'isbn'
+
+          scoped_search on: [:title]
+          scoped_search relation: :comments, on: [:comment]
+        end
+
+        class Comment < ActiveRecord::Base
+          belongs_to :book, foreign_key: 'isbn', primary_key: 'isbn'
+        end
+
+        @book1 = Book.create(:title => 'Eloquent Ruby', :isbn => '978-0321584106')
+        @book2 = Book.create(:title => 'The Well-Grounded Rubyist', :isbn => '978-1617295218')
+        Comment.create(:comment => 'Definitely worth a read', :isbn => @book1.isbn)
+        Comment.create(:comment => 'Wait what? I expected a book about gemstones', :isbn => @book1.isbn)
+        Comment.create(:comment => 'Cool book about ruby', :isbn => @book2.isbn)
+      end
+
+      after do
+        ActiveRecord::Migration.drop_table :comments
+        ActiveRecord::Migration.drop_table :books
+      end
+
+      it "correctly joins the tables" do
+        query = Book.search_for("test").to_sql
+        query.should =~ /LEFT OUTER JOIN "comments" ON "comments"\."isbn" = "books"."isbn"/
+        query.should =~ /"books"\."isbn" IN \(SELECT "isbn"/
+      end
+
+      it "finds the right results" do
+        Book.search_for('python').should == []
+        Book.search_for('comment ~ Wait').should == [@book1]
+        Book.search_for('comment ~ book').pluck(:id).sort.uniq.should == [@book1, @book2].map(&:id).sort
+        Book.search_for('comment ~ Cool').should == [@book2]
+      end
+    end
   end
 end


### PR DESCRIPTION
This will use the primary_key specified in the has_many relationship if it is defined. Otherwise, it will fall back to using the model's primary key.

This would fix https://github.com/wvanbergen/scoped_search/issues/197

I welcome feedback on this change. I'm not thrilled with the coercion of the field.relation symbol to string in the reflections lookup. And the `&.options` is defensive, no idea if the options hash is always defined or not, or there is a way that the field.relation wouldn't be listed in the reflections.

Anyhow, at least this is a starting point to discuss the feature.