### PR TITLE
Support ruby 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ rvm:
 - "2.5.1"
 - "2.6.0"
 - "2.7.1"
+- "3.0.0"
 - ruby-head
 - jruby-19mode
 - jruby-head
@@ -86,4 +87,14 @@ matrix:
     - rvm: "2.7.1"
       gemfile: Gemfile.activerecord52
     - rvm: "2.7.1"
+      gemfile: Gemfile.activerecord52_with_activesupport52
+    - rvm: "3.0.0"
+      gemfile: Gemfile.activerecord42
+    - rvm: "3.0.0"
+      gemfile: Gemfile.activerecord50
+    - rvm: "3.0.0"
+      gemfile: Gemfile.activerecord51
+    - rvm: "3.0.0"
+      gemfile: Gemfile.activerecord52
+    - rvm: "3.0.0"
       gemfile: Gemfile.activerecord52_with_activesupport52

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -306,7 +306,8 @@ module ScopedSearch
 
     # Defines a new search field for this search definition.
     def define(*args)
-      Field.new(self, *args)
+      options = args.last.is_a?(Hash) ? args.pop : {}
+      Field.new(self, *args, **options)
     end
 
     # Returns a reflection for a given klass and name

--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -305,9 +305,8 @@ module ScopedSearch
     end
 
     # Defines a new search field for this search definition.
-    def define(*args)
-      options = args.last.is_a?(Hash) ? args.pop : {}
-      Field.new(self, *args, **options)
+    def define(*args, **kwargs)
+      Field.new(self, *args, **kwargs)
     end
 
     # Returns a reflection for a given klass and name


### PR DESCRIPTION
This addresses the only issue I could find running tests under ruby 3.0.0.

A few tests fails when running under `Gemfile` but that seems to be due to an error with rails 6.1 and habtm joins. The same tests fails under ruby 2.7.2

Using `Gemfile.activerecord60_with_activesupport60` all tests runs under ruby 3.0.0 after this fix.

Closes #203
