### PR TITLE
Fix search through relations in Rails 6.1 (undefined method join_keys)

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -6,7 +6,7 @@ Please add an entry to the "Unreleased changes" section in your pull requests.
 
 === Unreleased changes
 
-- Nothing yet
+- Fix querying through associations in Rails 6.1 (undefined method join_keys) (#201)
 
 === Version 4.1.8
 


### PR DESCRIPTION
reflection.join_keys is no longer available. Extract the
join_primary_key and join_foreign_key explicitly.

Using the workaround provided by @stevequinlan this fixes the 57 test failures mentioned in #201.