### PR TITLE
Ruby 3 and rails 6.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ gemfile:
 - Gemfile.activerecord52_with_activesupport52
 - Gemfile.activerecord60
 - Gemfile.activerecord60_with_activesupport60
+- Gemfile.activerecord61
+- Gemfile.activerecord61_with_activesupport61
 
 matrix:
   allow_failures:
@@ -78,6 +80,26 @@ matrix:
       gemfile: Gemfile.activerecord60_with_activesupport60
     - rvm: "2.4.0"
       gemfile: Gemfile.activerecord60_with_activesupport60
+    - rvm: "2.0"
+      gemfile: Gemfile.activerecord61
+    - rvm: "2.1"
+      gemfile: Gemfile.activerecord61
+    - rvm: "2.2.2"
+      gemfile: Gemfile.activerecord61
+    - rvm: "2.3.7"
+      gemfile: Gemfile.activerecord61
+    - rvm: "2.4.0"
+      gemfile: Gemfile.activerecord61
+    - rvm: "2.0"
+      gemfile: Gemfile.activerecord61_with_activesupport61
+    - rvm: "2.1"
+      gemfile: Gemfile.activerecord61_with_activesupport61
+    - rvm: "2.2.2"
+      gemfile: Gemfile.activerecord61_with_activesupport61
+    - rvm: "2.3.7"
+      gemfile: Gemfile.activerecord61_with_activesupport61
+    - rvm: "2.4.0"
+      gemfile: Gemfile.activerecord61_with_activesupport61
     - rvm: "2.7.1"
       gemfile: Gemfile.activerecord42
     - rvm: "2.7.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ rvm:
 - "2.5.1"
 - "2.6.0"
 - "2.7.1"
-- "3.0.0"
+- "3.0.2"
 - ruby-head
 - jruby-19mode
 - jruby-head
@@ -110,13 +110,13 @@ matrix:
       gemfile: Gemfile.activerecord52
     - rvm: "2.7.1"
       gemfile: Gemfile.activerecord52_with_activesupport52
-    - rvm: "3.0.0"
+    - rvm: "3.0.2"
       gemfile: Gemfile.activerecord42
-    - rvm: "3.0.0"
+    - rvm: "3.0.2"
       gemfile: Gemfile.activerecord50
-    - rvm: "3.0.0"
+    - rvm: "3.0.2"
       gemfile: Gemfile.activerecord51
-    - rvm: "3.0.0"
+    - rvm: "3.0.2"
       gemfile: Gemfile.activerecord52
-    - rvm: "3.0.0"
+    - rvm: "3.0.2"
       gemfile: Gemfile.activerecord52_with_activesupport52

--- a/Gemfile.activerecord61
+++ b/Gemfile.activerecord61
@@ -1,0 +1,17 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'actionview', '~> 6.1.0'
+gem 'activerecord', '~> 6.1.0'
+
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+end
+
+platforms :ruby do
+  gem 'sqlite3', '~> 1.4'
+  gem 'mysql2', '> 0.5'
+  gem 'pg', '>= 0.18', '< 2.0'
+end

--- a/Gemfile.activerecord61_with_activesupport61
+++ b/Gemfile.activerecord61_with_activesupport61
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'actionview', '~> 6.1.0'
+gem 'activerecord', '~> 6.1.0'
+gem 'activesupport', '~> 6.1.0'
+
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+end
+
+platforms :ruby do
+  gem 'sqlite3', '~> 1.4'
+  gem 'mysql2', '> 0.5'
+  gem 'pg', '>= 0.18', '< 2.0'
+end

--- a/lib/scoped_search.rb
+++ b/lib/scoped_search.rb
@@ -34,9 +34,9 @@ module ScopedSearch
 
       definitions.each do |definition|
         if definition[:on].kind_of?(Array)
-          definition[:on].each { |field| self.scoped_search_definition.define(definition.merge(:on => field)) }
+          definition[:on].each { |field| self.scoped_search_definition.define(**definition.merge(:on => field)) }
         else
-          self.scoped_search_definition.define(definition)
+          self.scoped_search_definition.define(**definition)
         end
       end
       return self.scoped_search_definition

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -290,8 +290,14 @@ module ScopedSearch
       table_names = [many_class.table_name] + join_reflections.map(&:table_name)
 
       join_reflections.zip(table_names.zip(join_reflections.drop(1))).reduce(sql) do |acc, (reflection, (previous_table, next_reflection))|
-        klass = reflection.method(:join_keys).arity == 1 ? [reflection.klass] : [] # ActiveRecord <5.2 workaround
-        fk1, pk1 = reflection.join_keys(*klass).values # We are joining the tables "in reverse", so the PK and FK are swapped
+        if reflection.respond_to?(:join_keys)
+          klass = reflection.method(:join_keys).arity == 1 ? [reflection.klass] : [] # ActiveRecord <5.2 workaround
+          fk1, pk1 = reflection.join_keys(*klass).values # We are joining the tables "in reverse", so the PK and FK are swapped
+        else
+          fk1 = reflection.join_primary_key
+          pk1 = reflection.join_foreign_key
+        end
+
 
         # primary and foreign keys + optional conditions for the joins
         join_condition = if with_polymorphism?(reflection)


### PR DESCRIPTION
Should properly fix ruby 3 support by actually using kwargs to pass data forward

Also fixes support for rails 6.1 which was broken for has and many through joins due to [then change in this commit](https://github.com/rails/rails/commit/fc0090b300defb53fb53e2b030e034cb0fb89b8a).

- Properly support ruby 3.0.0
- Fix compatibility with rails 6.1
- Run travis ci using latest ruby 3.0 release
