### PR TITLE
Honor TZ when searching on temporal fields by relative dates

### DIFF
--- a/spec/integration/ordinal_querying_spec.rb
+++ b/spec/integration/ordinal_querying_spec.rb
@@ -210,6 +210,12 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         @class.search_for('timestamp > "3 hours ago"').length.should == 4
       end
 
+      it "should take timezone into consideration" do
+        now = Time.now
+        expected = DateTime.new(now.year, now.month, now.day, 0, 0, 0, now.zone).utc.strftime('%Y-%m-%d %H:%M:%S')
+        @class.search_for('timestamp > yesterday').to_sql.should include(expected)
+      end
+
       it "should accept 1 week from now as date format" do
         @class.search_for('date < "1 week from now"').length.should == 6
       end

--- a/spec/integration/rails_helper_spec.rb
+++ b/spec/integration/rails_helper_spec.rb
@@ -9,54 +9,54 @@ describe ScopedSearch::RailsHelper do
   let(:params) { HashWithIndifferentAccess.new(:controller => "resources", :action => "search") }
 
   it "should generate a link with the order param set" do
-    should_receive(:url_for).with(
+    should_receive(:url_for).with({
       "controller" => "resources",
       "action" => "search",
       "order" => "field ASC"
-    ).and_return("/example")
+    }).and_return("/example")
 
     sort("field")
   end
 
   it "should generate a link with order param set to alternative default sorting order" do
-    should_receive(:url_for).with(
+    should_receive(:url_for).with({
       "controller" => "resources",
       "action" => "search",
       "order" => "field DESC"
-    ).and_return("/example")
+    }).and_return("/example")
 
     sort("field", :default => "DESC")
   end
 
   it "should generate a link with the order param inverted" do
-    should_receive(:url_for).with(
+    should_receive(:url_for).with({
       "controller" => "resources",
       "action" => "search",
       "order" => "field DESC"
-    ).and_return("/example")
+    }).and_return("/example")
 
     params[:order] = "field ASC"
     sort("field")
   end
 
   it "should generate a link with other parameters retained" do
-    should_receive(:url_for).with(
+    should_receive(:url_for).with({
       "controller" => "resources",
       "action" => "search",
       "walrus" => "unicorns",
       "order" => "field ASC"
-    ).and_return("/example")
+    }).and_return("/example")
 
     params[:walrus] = "unicorns"
     sort("field")
   end
 
   it "should replace the current sorting order" do
-    should_receive(:url_for).with(
+    should_receive(:url_for).with({
       "controller" => "resources",
       "action" => "search",
       "order" => "other ASC"
-    ).and_return("/example")
+    }).and_return("/example")
 
     params[:order] = "field ASC"
     sort("other")
@@ -83,12 +83,12 @@ describe ScopedSearch::RailsHelper do
     let(:ac_params) { double('ActionController::Parameters') }
 
     it "should call to_h on passed params object" do
-      should_receive(:url_for).with(
+      should_receive(:url_for).with({
         "controller" => "resources",
         "action" => "search",
         "walrus" => "unicorns",
         "order" => "field ASC"
-      ).and_return("/example")
+      }).and_return("/example")
 
       params[:walrus] = "unicorns"
 


### PR DESCRIPTION
Previously queries like 'yesterday' would resolve to only a specific
date, discarding any information about the user's time zone. After this
change, `datetime` and `timestamp` fields take the time zone into
consideration.