### PR TITLE
Fix searching on set values when only the key is provided

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -450,7 +450,9 @@ module ScopedSearch
           field = definition.field_by_name(value)
           if field && field.set? && field.complete_value.values.include?(true)
             key = field.complete_value.map{|k,v| k if v == true}.compact.first
-            return builder.set_test(field, :eq, key, &block)
+            sql, *params = builder.set_test(field, :eq, key, &block)
+            params.each { |p| yield(:parameter, p) }
+            return sql
           end
           # Search keywords found without context, just search on all the default fields
           fragments = definition.default_fields_for(value).map do |field|

--- a/spec/integration/set_query_spec.rb
+++ b/spec/integration/set_query_spec.rb
@@ -12,6 +12,7 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
       @class = ScopedSearch::RSpec::Database.create_model(:bool => :boolean, :status => :integer) do |klass|
         klass.scoped_search :on => :bool, :complete_value => {:yes => true, :no => false}
         klass.scoped_search :on => :status, :complete_value => {:unknown => 0, :up => 1, :down => 2}
+        klass.scoped_search :on => :bool, :rename => :bool2, :complete_value => {:true => true, :false => false}
       end
     end
 
@@ -70,6 +71,11 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
 
       it "should find two record with bool = false" do
         @class.search_for('bool != yes').length.should == 2
+      end
+
+      it "should be able to search without value" do
+        @class.search_for('bool').length.should == 1
+        @class.search_for('bool2').length.should == 1
       end
     end
   end


### PR DESCRIPTION
Without this change we were running into errors like this:
```
ActiveRecord::PreparedStatementInvalid:
  wrong number of bind variables (0 for 1) in: (("model_0018166730307353163"."bool" <> ?))
```