### PR TITLE
Validate both in and notin the same way

### DIFF
--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -509,7 +509,7 @@ module ScopedSearch
           raise ScopedSearch::QueryNotSupported, "Field '#{lhs.value}' not recognized for searching!" unless field
 
           # see if the value passes user defined validation
-          if operator == :in
+          if [:in, :notin].include?(operator)
             rhs.value.split(',').each { |v| validate_value(field, v) }
           else
             validate_value(field, rhs.value)

--- a/spec/unit/query_builder_spec.rb
+++ b/spec/unit/query_builder_spec.rb
@@ -68,6 +68,8 @@ describe ScopedSearch::QueryBuilder do
 
     lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field ^ (1,2)') }.should_not raise_error
     lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field ^ (1,a)') }.should raise_error(ScopedSearch::QueryNotSupported)
+    lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field !^ (1,2)') }.should_not raise_error
+    lambda { ScopedSearch::QueryBuilder.build_query(@definition, 'test_field !^ (1,a)') }.should raise_error(ScopedSearch::QueryNotSupported)
   end
 
   it "should display custom error from validator" do


### PR DESCRIPTION
This commit fixes the following error

Model.search_for("id !^ (2,3)") fails with
ScopedSearch::QueryNotSupported: Value '2,3' is not valid for field 'id'

It does it by splitting value for both in and not in