### PR TITLE
Add enhanced filter to autocomplete

### DIFF
--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -207,8 +207,7 @@ module ScopedSearch
 
     def complete_value_from_db(field, special_values, val)
       count = 20 - special_values.count
-      completer_scope(field)
-        .where(@options[:value_filter])
+      filtered_completer_scope(field)
         .where(value_conditions(field.quoted_field, val))
         .select(field.quoted_field)
         .limit(count)
@@ -216,6 +215,15 @@ module ScopedSearch
         .map(&field.field)
         .compact
         .map { |v| v.to_s =~ /\s/ ? "\"#{v.gsub('"', '\"')}\"" : v }
+    end
+
+    def filtered_completer_scope(field)
+      scope = completer_scope(field)
+      return scope.where(@options[:value_filter]) unless @options[:enhanced_filter]
+      if field.klass.column_names.include?(@options[:enhanced_filter][:has_column])
+        return scope.where(@options[:enhanced_filter][:filter])
+      end
+      scope
     end
 
     def completer_scope(field)

--- a/spec/integration/auto_complete_spec.rb
+++ b/spec/integration/auto_complete_spec.rb
@@ -267,5 +267,17 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         Foo.complete_for('int =', value_filter: { qux_id: 99 }).should == []
       end
     end
+
+    context 'autocompleting with enhanced_filter' do
+      it 'should return filtered values' do
+        Foo.complete_for('int =', enhanced_filter: { has_column: "int", filter: { qux_id: @qux_2.id } }).should == ['int = 10']
+      end
+      it 'should take precedence over value_filter' do
+        Foo.complete_for('int =', value_filter: { qux_id: @qux_1.id }, enhanced_filter: { has_column: "int", filter: { qux_id: @qux_2.id } }).should == ['int = 10']
+      end
+      it 'should ignore invalid filter' do
+        Foo.complete_for('int =', enhanced_filter: { has_column: "invalid_column_name", filter: { qux_id: @qux_1.id } }).should == ["int = 9", "int = 10", "int = 22"]
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new field, `enhanced_filter` to `AutoCompleteBuilder`.
`enhanced_filter` takes the following arguments:

- `has_column` - Name of the required column
- `filter` - Predicate used for filtering

Iff in the table to be filtered, there exists a column `<has_column>`, the filter will be executed. 

Consider the following example:
![image](https://github.com/wvanbergen/scoped_search/assets/99347625/c091a3c6-9baf-4039-ba4f-cfb1746918f5)

Let's say the table **Food** is populated with a green apple and a red pepper.
If I want to filter for green food, I would do `value_filter: {color_id: <green_id>}`.
This works as long as a user doesn't try to filter this by `type = `. In that case, `value_filter` will be applied to the table **Type**, which doesn't have a `color_id` column, causing an exception.
`enhanced_filter` prevents this by first checking for the existence of the required column before filtering.