### PR TITLE
Show a specific error for an unintended "not null" query

### DIFF
--- a/lib/scoped_search.rb
+++ b/lib/scoped_search.rb
@@ -62,6 +62,13 @@ module ScopedSearch
   class QueryNotSupported < ScopedSearch::Exception
   end
 
+  # The specific exception class that is raised when a query is interpreted
+  # as referencing a non-existent database column
+  #
+  # You may want to catch this exception to inform the user.
+  class ColumnNotFound < ScopedSearch::Exception
+  end
+
 end
 
 # Load all lib files

--- a/lib/scoped_search/query_builder.rb
+++ b/lib/scoped_search/query_builder.rb
@@ -473,7 +473,7 @@ module ScopedSearch
         # Returns an IS (NOT) NULL SQL fragment
         def to_null_sql(builder, definition, &block)
           field = definition.field_by_name(rhs.value)
-          raise ScopedSearch::QueryNotSupported, "Field '#{rhs.value}' not recognized for searching!" unless field
+          raise ScopedSearch::ColumnNotFound, "Field '#{rhs.value}' not found in #{definition.klass}!" unless field
 
           if field.key_field
             yield(:parameter, rhs.value.to_s.sub(/^.*\./,''))

--- a/spec/integration/string_querying_spec.rb
+++ b/spec/integration/string_querying_spec.rb
@@ -236,6 +236,17 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
       end
     end
 
+    context 'interpreted as a not_null operation' do
+
+      it "should reference the correct column" do
+        @class.search_for('has string').to_sql.should include('"string" IS NOT NULL')
+      end
+
+      it "should raise a specific error with a missing column" do
+        lambda { @class.search_for('has wakka') }.should raise_error(ScopedSearch::ColumnNotFound, "Field 'wakka' not found in #{@class}!")
+      end
+    end
+
     context 'using order' do
       it "sort by string ASC" do
         @class.search_for('', :order => 'string ASC').first.string.should eql('bar')


### PR DESCRIPTION
The same error and message is used for many different ambiguous query compositions. In the case of the `has` keyword, it's such a common part of speech that it could inadvertently creep into a naïve query: "walter has a big nose" might throw the same error (unless you have a column in your database named `a`) as many other cases. This makes it difficult to understand, since that generic error message is designed to serve so many purposes.

This PR introduces a specific error to be used for a missing or unmatched field, and the error message includes both the parent class and the specific token which has been interpreted as a field name by the query builder.