### PR TITLE
Allow use of logical operators with single arg

### DIFF
--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -107,6 +107,21 @@ describe ScopedSearch::QueryLanguage::Parser do
     '& & & & a & b & & &'.should parse_to([:and, 'a', 'b'])
   end
 
+  it 'should parse in and not in operators with no lhs' do
+    '^ a'.should parse_to([:eq, 'a'])
+    '^ a b'.should parse_to([:or, [:eq, 'a'], [:eq, 'b']])
+    '^ a,b'.should parse_to([:or, [:eq, 'a'], [:eq, 'b']])
+
+    '^ (a b)'.should parse_to([:or, [:eq, 'a'], [:eq, 'b']])
+    '^ (a,b)'.should parse_to([:or, [:eq, 'a'], [:eq, 'b']])
+
+    '!^ a'.should parse_to([:ne, 'a'])
+    '!^ a b'.should parse_to([:and, [:ne, 'a'], [:ne, 'b']])
+    '!^ a,b'.should parse_to([:and, [:ne, 'a'], [:ne, 'b']])
+    '!^ (a b)'.should parse_to([:and, [:ne, 'a'], [:ne, 'b']])
+    '!^ (a,b)'.should parse_to([:and, [:ne, 'a'], [:ne, 'b']])
+  end
+
   it "should refuse to parse an empty not expression" do
     lambda { ScopedSearch::QueryLanguage::Compiler.parse('!()|*') }.should raise_error(ScopedSearch::QueryNotSupported)
   end

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -102,7 +102,12 @@ describe ScopedSearch::QueryLanguage::Parser do
     'set? a b null? c'.should parse_to([:and, [:notnull, 'a'], 'b', [:null, 'c']])
   end
 
+  it 'should parse logical operators with a single argument' do
+    '& a'.should parse_to('a')
+    '& & & & a & b & & &'.should parse_to([:and, 'a', 'b'])
+  end
+
   it "should refuse to parse an empty not expression" do
     lambda { ScopedSearch::QueryLanguage::Compiler.parse('!()|*') }.should raise_error(ScopedSearch::QueryNotSupported)
-  end  
+  end
 end


### PR DESCRIPTION
Previously, searching for things like `& thing` constructed the AST incorrectly. Parsing `& thing` would produce the AST which would simplify into `<AST::OperatorNode [:and, "thing"]>`, which then couldn't really be used for searching.

This change builds the AST fully, meaning this will accept even things like `& & & & & & thing` which will then simplify into a single LeafNode.