### PR TITLE
Wrap all string autocomplete values in quotes, not just those containing whitespace

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -6,6 +6,8 @@ Please add an entry to the "Unreleased changes" section in your pull requests.
 
 === Unreleased changes
 
+- Autocomplete now wraps all strings in quotes, not just those containing whitespace
+
 === Version 4.1.10
 
 - Fix querying through associations in Rails 6.1 (undefined method join_keys) (#201)

--- a/lib/scoped_search/auto_complete_builder.rb
+++ b/lib/scoped_search/auto_complete_builder.rb
@@ -215,7 +215,7 @@ module ScopedSearch
         .distinct
         .map(&field.field)
         .compact
-        .map { |v| v.to_s =~ /\s/ ? "\"#{v.gsub('"', '\"')}\"" : v }
+        .map { |v| v.is_a?(String) ? "\"#{v.gsub('"', '\"')}\"" : v }
     end
 
     def completer_scope(field)

--- a/spec/integration/auto_complete_spec.rb
+++ b/spec/integration/auto_complete_spec.rb
@@ -169,10 +169,10 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
       end
 
       it "should complete values should contain baz" do
-        Foo.complete_for('explicit = ').should contain('explicit =  baz')
+        Foo.complete_for('explicit = ').should contain('explicit =  "baz"')
       end
 
-      it "should complete values with quotes where required" do
+      it "should complete values with quotes where value is a string" do
         Foo.complete_for('alias = ').should contain('alias =  "temp \"2\""')
       end
     end


### PR DESCRIPTION
This change modifies AutoCompleteBuilder's `complete_value_from_db` method. 

Previously, DB values that were strings would automatically be wrapped in quotes if the values contained spaces.
Now, DB values that are strings are wrapped in quotes, regardless of contents.

This is so that special operators ('|', '>', etc) don't break queries. For a more detailed explanation of the issue, see https://github.com/theforeman/foreman_rh_cloud/pull/1083.
