### PR TITLE
Make UUID search case insensitive

### DIFF
--- a/lib/scoped_search/definition.rb
+++ b/lib/scoped_search/definition.rb
@@ -260,7 +260,7 @@ module ScopedSearch
 
     NUMERICAL_REGXP = /^\-?\d+(\.\d+)?$/
     INTEGER_REGXP = /^\-?\d+$/
-    UUID_REGXP = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/
+    UUID_REGXP = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i
 
     # Returns a list of appropriate fields to search in given a search keyword and operator.
     def default_fields_for(value, operator = nil)

--- a/spec/integration/uuid_query_spec.rb
+++ b/spec/integration/uuid_query_spec.rb
@@ -43,8 +43,9 @@ ScopedSearch::RSpec::Database.test_databases.each do |db|
         @class.search_for("uuid != #{@record3.uuid}").length.should == 2
       end
 
-      it "should find a record by just specifying the uuid" do
+      it "should find a record by just specifying the uuid (case insensitive)" do
         @class.search_for(@record1.uuid).first.uuid.should == @record1.uuid
+        @class.search_for(@record1.uuid.upcase).first.uuid.should == @record1.uuid
       end
 
       it "should not find a record if the uuid is not a valid uuid" do


### PR DESCRIPTION
When searching for a UUID, input should be accepted independent of case because
[RFC 4122 Section 3](https://datatracker.ietf.org/doc/html/rfc4122#section-3) states:

```
The hexadecimal values "a" through "f" are output as
lower case characters and are case insensitive on input.
```