### PR TITLE
Add Rails 7.0 and Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,6 +22,7 @@ jobs:
         ruby_version:
           - '2.7'
           - '3.0'
+          - '3.3'
           - ruby-head
           - jruby-head
         appraisal:
@@ -29,6 +30,8 @@ jobs:
           - rails-6.0-activesupport
           - rails-6.1
           - rails-6.1-activesupport
+          - rails-7.0
+          - rails-7.0-activesupport
     services:
       postgres:
         image: postgres:12.1

--- a/Appraisals
+++ b/Appraisals
@@ -1,4 +1,4 @@
-['6.0', '6.1'].each do |version|
+['6.0', '6.1', '7.0'].each do |version|
   appraise "rails-#{version}" do
     gem 'actionview', "~> #{version}.0"
     gem 'activerecord', "~> #{version}.0"


### PR DESCRIPTION
I've included https://github.com/wvanbergen/scoped_search/pull/235 since it quite cleans up the current state and I'd really like to have it first.

Otherwise, the second commit only adds Rails 7.0 and Ruby 3.3 to the matrix. I've run the test suite locally and it passed as well as some search_scope related tests in Foreman and they seem to be green. So I don't think we need any changes here to just run the library on those Rails/Ruby versions. Although, if we really want to actually support Ruby 3.3, we'd need some more droppings, minimal version checks, etc.

The library heavily relies on Rails rather then Ruby, so I'd rather expect some changes when we add Rails 7.1 support, but that's just a hunch since it seem to just work on Rails 7.0 along side with Rails 6.0.